### PR TITLE
Finish rename to import assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Import Conditions and JSON modules
+# Import Assertions and JSON modules
 
 Champions: Sven Sauleau ([@xtuc](https://github.com/xtuc)), Daniel Ehrenberg ([@littledan](https://github.com/littledan)), Myles Borins ([@MylesBorins](https://github.com/MylesBorins)), and Dan Clark ([@dandclark](https://github.com/dandclark))
 
@@ -8,9 +8,9 @@ Please leave any feedback you have in the [issues](http://github.com/tc39/propos
 
 ## Synopsis
 
-The Import Conditions and JSON modules proposal adds:
+The Import Assertions and JSON modules proposal adds:
 - An inline syntax for module import statements to pass on more information alongside the module specifier
-- An initial application for such conditions in supporting JSON modules in a common way across JavaScript environments
+- An initial application for such assertions in supporting JSON modules in a common way across JavaScript environments
 
 Developers will then be able to import a JSON module as follows:
 ```js
@@ -46,23 +46,23 @@ This proposal pursues the third option, as we expect it to lead to the best deve
 
 ## Proposed syntax
 
-Import conditions have to be made available in several different contexts. This section contains one possible syntax, but there are other options, discussed in [#6](https://github.com/tc39/proposal-import-conditions/issues/6).
+Import assertions have to be made available in several different contexts. This section contains one possible syntax, but there are other options, discussed in [#6](https://github.com/tc39/proposal-import-conditions/issues/6).
 
 Here, a key-value syntax is used, with the key `type` used as an example indicating the module type. Such key-value syntax can be used in various different contexts.
 
 ### import statements
 
-The ImportDeclaration would allow any arbitrary conditions after the `assert` keyword.
+The ImportDeclaration would allow any arbitrary assertions after the `assert` keyword.
 
-For example, the `type` attribute indicates a module type, and can be used to load JSON modules with the following syntax.
+For example, the `type` assertion indicates a module type, and can be used to load JSON modules with the following syntax.
 
 ```mjs
 import json from "./foo.json" assert { type: "json" };
 ```
 
 The `assert` syntax in the `ImportDeclaration` statement uses curly braces, for the following reasons (as discussed in [#5](https://github.com/tc39/proposal-import-conditions/issues/5)):
-- JavaScript developers are already used to the Object literal syntax and since it allows a trailing comma copy/pasting conditions will be easy.
-- Follow-up proposals might specify new types of import conditions (see [Restriction to condition attributes](https://github.com/tc39/proposal-import-conditions#restriction-to-condition-attributes)) and we will be able to group conditions with different keywords, for instance:
+- JavaScript developers are already used to the Object literal syntax and since it allows a trailing comma copy/pasting assertions will be easy.
+- Follow-up proposals might specify new types of import attributes (see [Follow-up proposal "evaluator attributes"](https://github.com/tc39/proposal-import-conditions#follow-up-proposal-evaluator-attributes)) and we will be able to group attributes with different keywords, for instance:
 ```js
 import json from "./foo.json" assert { type: "json" } with { transformA: "value" };
 ```
@@ -71,13 +71,13 @@ The `assert` keyword is designed to match the check-only semantics. As shown by 
 
 ### dynamic import()
 
-The `import()` pseudo-function would allow import conditions to be indicated in an options bag in the second argument.
+The `import()` pseudo-function would allow import assertions to be indicated in an options bag in the second argument.
 
 ```js
 import("foo.json", { assert: { type: "json" } })
 ```
 
-The second parameter to `import()` is an options bag, with the only option currently defined to be `assert`: the value here is an object containing the import conditions. There are no other current proposals for entries to put in the options bag, but better safe than sorry with forward-compatibility.
+The second parameter to `import()` is an options bag, with the only option currently defined to be `assert`: the value here is an object containing the import assertions. There are no other current proposals for entries to put in the options bag, but better safe than sorry with forward-compatibility.
 
 ### Integration of modules into environments
 
@@ -103,7 +103,7 @@ Although changes to HTML won't be specified by TC39, an idea here would be that 
 
 #### WebAssembly
 
-In the context of the [WebAssembly/ESM integration proposal](https://github.com/webassembly/esm-integration): For imports of other module types from within a WebAssembly module, this proposal would introduce a new custom section (named `importconditions`) that will annotate with conditions each imported module (which is listed in the import section).
+In the context of the [WebAssembly/ESM integration proposal](https://github.com/webassembly/esm-integration): For imports of other module types from within a WebAssembly module, this proposal would introduce a new custom section (named `importassertions`) that will annotate with assertions each imported module (which is listed in the import section).
 
 ## Proposed semantics and interoperability
 
@@ -117,19 +117,19 @@ All of the import statements in the module graph that address the same JSON modu
 
 Each JavaScript host is expected to provide a secondary way of checking whether a module is a JSON module. For example, on the Web, the MIME type would be checked to be a JSON MIME type. In "local" desktop/server/embedded environments, the file extension may be checked (possibly after symlinks are followed). The `type: "json"` is indicated at the import site, rather than *only* through that other mechanism in order to prevent the privilege escalation issue noted in the opening section.
 
-Nevertheless, the interpretation of module loads with no conditions remains host/implementation-defined, so it is valid to implement JSON modules without *requiring* `assert { type: "json" }`. It's just that `assert { type: "json" }` must be supported everywhere. For example, it will be up to Node.js, not TC39, to decide whether import conditions are required or optional for JSON modules.
+Nevertheless, the interpretation of module loads with no assertions remains host/implementation-defined, so it is valid to implement JSON modules without *requiring* `assert { type: "json" }`. It's just that `assert { type: "json" }` must be supported everywhere. For example, it will be up to Node.js, not TC39, to decide whether import assertions are required or optional for JSON modules.
 
-### Import conditions
+### Import assertions
 
-Hosts would all be required to give a common interpretation to `"json"`, defined in the JavaScript specification, that `json` is the parsed JSON document (no named exports). Further conditions and module types beyond `json` modules could be added in future TC39 proposals as well as by hosts. HTML and CSS modules are also under consideration, and these may use similar explicit `type` syntax when imported.
+Hosts would all be required to give a common interpretation to `"json"`, defined in the JavaScript specification, that `json` is the parsed JSON document (no named exports). Further assertions and module types beyond `json` modules could be added in future TC39 proposals as well as by hosts. HTML and CSS modules are also under consideration, and these may use similar explicit `type` syntax when imported.
 
-JavaScript implementations are encouraged to reject conditions and type values which are not implemented in their environment (rather than ignoring them). This is to allow for maximal flexibility in the design space in the future--in particular, it enables new import conditions to be defined which change the interpretation of a module, without breaking backwards-compatibility.
+JavaScript implementations are encouraged to reject assertions and type values which are not implemented in their environment (rather than ignoring them). This is to allow for maximal flexibility in the design space in the future--in particular, it enables new import assertions to be defined which change the interpretation of a module, without breaking backwards-compatibility.
 
 Note that all environments are required to support JSON modules with this explicit syntax, but *may* support modules without it. For example, on the Web, JSON modules would only be supported with the explicit type, but Node.js *may* decide to also support JSON modules without this declaration. However, all environments *must* support the explicitly `type`-declared JSON modules.
 
 ### Follow-up proposal "evaluator attributes"
 
-Conditions do not affect the contents of the module or form part of the cache key.
+Assertions do not affect the contents of the module or form part of the cache key.
 Future follow-up proposals may relax this restriction with "evaluator attributes" that would change the contents of the module.
 
 There are three possible ways to handle multiple imports of the same module with "evaluator attributes":
@@ -168,7 +168,7 @@ The topic of attribute divergence is further discussed in  [#34](https://github.
 
 ### How would this proposal work with caching?
 
-Conditions are not part of the module cache key. Implementations are required to return the same module, or an error, regardless of the conditions.
+Assertions are not part of the module cache key. Implementations are required to return the same module, or an error, regardless of the assertions.
 
 ### Why don't JSON modules support named exports?
 
@@ -178,17 +178,17 @@ Conditions are not part of the module cache key. Implementations are required to
 
 ### Why not use more terse syntax to indicate module types, like `import json from "./foo.json" as "json"`?
 
-Another option considered and not selected has been to use a single string as the attribute, indicating the type. This option is not selected due to its implication that any particular attribute is special; even though this proposal only specifies the `type` attribute, the intention is to be open to more conditions in the future. (discussion in [#12](https://github.com/tc39/proposal-import-conditions/issues/12)).
+Another option considered and not selected has been to use a single string as the attribute, indicating the type. This option is not selected due to its implication that any particular attribute is special; even though this proposal only specifies the `type` attribute, the intention is to be open to more assertions in the future. (discussion in [#12](https://github.com/tc39/proposal-import-conditions/issues/12)).
 
 ### Should more than just strings be supported as attribute values?
 
-We could permit import conditions to have more complex values than simply strings, for example:
+We could permit import assertions to have more complex values than simply strings, for example:
 
 ```js
 import value from "module" assert attr: { key1: "value1", key2: [1, 2, 3] };
 ```
 
-This would allow import conditions to scale to support a larger variety of metadata.
+This would allow import assertions to scale to support a larger variety of metadata.
 
 We propose to omit this generalization in the initial proposal, as a key/value list of strings already affords significant flexibility to start, but we're open to a follow-on proposal providing this kind of generalization.
 
@@ -224,7 +224,7 @@ import value from "module" when { type: 'json' };
 import value from "module" given { type: 'json' };
 ```
 
-- How dynamic import would accept import conditions:
+- How dynamic import would accept import assertions:
 ```mjs
 import("foo.wasm", { assert: { type: "webassembly" } });
 ```
@@ -240,8 +240,8 @@ However, that's not possible with the `Worker` API since it already uses an obje
 
 #### Before Stage 4
 
-- The integration of import conditions into various host environments.
-    - For example, in the Web Platform, how import conditions would be enabled when launching a worker (if that is supported in the initial version to be shipped on the Web) or included in a `<script>` tag.
+- The integration of import assertions into various host environments.
+    - For example, in the Web Platform, how import assertions would be enabled when launching a worker (if that is supported in the initial version to be shipped on the Web) or included in a `<script>` tag.
 
 ```mjs
 new Worker("foo.wasm", { type: "module", assert: { type: "webassembly" } });

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Champions: Sven Sauleau ([@xtuc](https://github.com/xtuc)), Daniel Ehrenberg ([@
 
 Status: Stage 2.
 
-Please leave any feedback you have in the [issues](http://github.com/tc39/proposal-import-conditions/issues)!
+Please leave any feedback you have in the [issues](http://github.com/tc39/proposal-import-assertions/issues)!
 
 ## Synopsis
 
@@ -26,7 +26,7 @@ However, in [an issue](https://github.com/w3c/webcomponents/issues/839), Ryosuke
 
 Some developers have the intuition that the file extension could be used to determine the module type, as it is in many existing non-standard module systems. However, it's a deep web architectural principle that the suffix of the URL (which you might think of as the "file extension" outside of the web) does not lead to semantics of how the page is interpreted. In practice, on the web, there is a widespread [mismatch between file extension and the HTTP Content Type header](content-type-vs-file-extension.md). All of this sums up to it being infeasible to depend on file extensions/suffixes included in the module specifier to be the basis for this checking.
 
-There are other possible pieces of metadata which could be associated with modules, see [#8](https://github.com/tc39/proposal-import-conditions/issues/8) for further discussion.
+There are other possible pieces of metadata which could be associated with modules, see [#8](https://github.com/tc39/proposal-import-assertions/issues/8) for further discussion.
 
 Proposed ES module types that are blocked by this security concern, in addition to JSON modules, include [CSS modules](https://github.com/whatwg/html/pull/4898) and potentially [HTML modules](https://github.com/whatwg/html/pull/4505) if the HTML module  proposal is restricted to [not allow script](https://github.com/w3c/webcomponents/issues/805).
 
@@ -34,11 +34,11 @@ Proposed ES module types that are blocked by this security concern, in addition 
 
 There are three places where this data could be provided:
 - As part of the module specifier (e.g., as a pseudo-scheme)
-    - Challenges: Adds complexity to URLs or other module specifier syntaxes, and risks being confusing to developers (further discussion: [#11](https://github.com/tc39/proposal-import-conditions/issues/11))
+    - Challenges: Adds complexity to URLs or other module specifier syntaxes, and risks being confusing to developers (further discussion: [#11](https://github.com/tc39/proposal-import-assertions/issues/11))
     - webpack supports this sort of construct ([docs](https://webpack.js.org/concepts/loaders/#inline)).
         - Demand from users for similar behavior in Parcel, with pushback from some maintainers ([#3477](https://github.com/parcel-bundler/parcel/issues/3477))
 - Separately, out of band (e.g., a separate resource file)
-    - Challenges: How to load that resource file; what should the format be; unergonomic to have to jump between files during development (further discussion: [#13](https://github.com/tc39/proposal-import-conditions/issues/13))
+    - Challenges: How to load that resource file; what should the format be; unergonomic to have to jump between files during development (further discussion: [#13](https://github.com/tc39/proposal-import-assertions/issues/13))
 - In the JavaScript source text
     - Challenges: Requires a change at the JavaScript language level (this proposal)
 
@@ -46,7 +46,7 @@ This proposal pursues the third option, as we expect it to lead to the best deve
 
 ## Proposed syntax
 
-Import assertions have to be made available in several different contexts. This section contains one possible syntax, but there are other options, discussed in [#6](https://github.com/tc39/proposal-import-conditions/issues/6).
+Import assertions have to be made available in several different contexts. This section contains one possible syntax, but there are other options, discussed in [#6](https://github.com/tc39/proposal-import-assertions/issues/6).
 
 Here, a key-value syntax is used, with the key `type` used as an example indicating the module type. Such key-value syntax can be used in various different contexts.
 
@@ -60,9 +60,9 @@ For example, the `type` assertion indicates a module type, and can be used to lo
 import json from "./foo.json" assert { type: "json" };
 ```
 
-The `assert` syntax in the `ImportDeclaration` statement uses curly braces, for the following reasons (as discussed in [#5](https://github.com/tc39/proposal-import-conditions/issues/5)):
+The `assert` syntax in the `ImportDeclaration` statement uses curly braces, for the following reasons (as discussed in [#5](https://github.com/tc39/proposal-import-assertions/issues/5)):
 - JavaScript developers are already used to the Object literal syntax and since it allows a trailing comma copy/pasting assertions will be easy.
-- Follow-up proposals might specify new types of import attributes (see [Follow-up proposal "evaluator attributes"](https://github.com/tc39/proposal-import-conditions#follow-up-proposal-evaluator-attributes)) and we will be able to group attributes with different keywords, for instance:
+- Follow-up proposals might specify new types of import attributes (see [Follow-up proposal "evaluator attributes"](https://github.com/tc39/proposal-import-assertions#follow-up-proposal-evaluator-attributes)) and we will be able to group attributes with different keywords, for instance:
 ```js
 import json from "./foo.json" assert { type: "json" } with { transformA: "value" };
 ```
@@ -89,7 +89,7 @@ Host environments (e.g., the Web platform, Node.js) often provide various differ
 new Worker("foo.wasm", { type: "module", assert: { type: "webassembly" } });
 ```
 
-Sidebar about WebAssembly module types and the web: it's still uncertain whether importing WebAssembly modules would need to be marked specially, or would be imported just like JavaScript. Further discussion in [#19](https://github.com/tc39/proposal-import-conditions/issues/19).
+Sidebar about WebAssembly module types and the web: it's still uncertain whether importing WebAssembly modules would need to be marked specially, or would be imported just like JavaScript. Further discussion in [#19](https://github.com/tc39/proposal-import-assertions/issues/19).
 
 #### HTML
 
@@ -139,7 +139,7 @@ There are three possible ways to handle multiple imports of the same module with
 
 It's possible that one of these three options may make sense for a module load, on a case-by-case basis by attribute, but it's worth careful thought before making this choice.
 
-Plumbing-wise, the JavaScript standard would basically be responsible for passing the attributes up to the host environment, which would then decide how to interpret it, within the requirements listed above. Issues [#24](https://github.com/tc39/proposal-import-conditions/issues/24) and [#25](https://github.com/tc39/proposal-import-conditions/issues/25) discuss the Web and Node.js feature and semantic requirements respectively, and issue [#10](https://github.com/tc39/proposal-import-conditions/issues/10) discusses how to allow different JavaScript environments to have interoperability.
+Plumbing-wise, the JavaScript standard would basically be responsible for passing the attributes up to the host environment, which would then decide how to interpret it, within the requirements listed above. Issues [#24](https://github.com/tc39/proposal-import-assertions/issues/24) and [#25](https://github.com/tc39/proposal-import-assertions/issues/25) discuss the Web and Node.js feature and semantic requirements respectively, and issue [#10](https://github.com/tc39/proposal-import-assertions/issues/10) discusses how to allow different JavaScript environments to have interoperability.
 
 ## FAQ
 
@@ -164,7 +164,7 @@ However, at the same time, behavior of modules in general, and the set of module
 
 We see the management of compatibility issues across environments as similar, independent of whether metadata is held in-band or out-of-band. An out of band solution would also suffer from the risk of inconsistent implementation or support across host environments if some kind of coordination does not occur.
 
-The topic of attribute divergence is further discussed in  [#34](https://github.com/tc39/proposal-import-conditions/issues/34).
+The topic of attribute divergence is further discussed in  [#34](https://github.com/tc39/proposal-import-assertions/issues/34).
 
 ### How would this proposal work with caching?
 
@@ -178,7 +178,7 @@ Assertions are not part of the module cache key. Implementations are required to
 
 ### Why not use more terse syntax to indicate module types, like `import json from "./foo.json" as "json"`?
 
-Another option considered and not selected has been to use a single string as the attribute, indicating the type. This option is not selected due to its implication that any particular attribute is special; even though this proposal only specifies the `type` attribute, the intention is to be open to more assertions in the future. (discussion in [#12](https://github.com/tc39/proposal-import-conditions/issues/12)).
+Another option considered and not selected has been to use a single string as the attribute, indicating the type. This option is not selected due to its implication that any particular attribute is special; even though this proposal only specifies the `type` attribute, the intention is to be open to more assertions in the future. (discussion in [#12](https://github.com/tc39/proposal-import-assertions/issues/12)).
 
 ### Should more than just strings be supported as attribute values?
 
@@ -200,7 +200,7 @@ We are planning to make descisions and reach consensus during specific stages of
 
 We have achieved consensus on the following core decisions as part of Stage 2, including:
 
-- The attribute form; key-value or single string ([#12](https://github.com/tc39/proposal-import-conditions/issues/12))
+- The attribute form; key-value or single string ([#12](https://github.com/tc39/proposal-import-assertions/issues/12))
 
 ```mjs
 // Not selected
@@ -217,7 +217,7 @@ import value from "module" assert { type: "json" };
 
 After Stage 2 and before Stage 3, we're open to settling on some less core details, such as:
 
-- Considering alternatives for the `with`/`if`/`assert` keywords ([#3](https://github.com/tc39/proposal-import-conditions/issues/3))
+- Considering alternatives for the `with`/`if`/`assert` keywords ([#3](https://github.com/tc39/proposal-import-assertions/issues/3))
 
 ```mjs
 import value from "module" when { type: 'json' };
@@ -247,9 +247,9 @@ However, that's not possible with the `Worker` API since it already uses an obje
 new Worker("foo.wasm", { type: "module", assert: { type: "webassembly" } });
 ```
 
-Standardization here would consist of building consensus not just in TC39 but also in WHATWG HTML as well as the Node.js ESM effort and a general audit of semantic requirements across various host environments ([#10](https://github.com/tc39/proposal-import-conditions/issues/10), [#24](https://github.com/tc39/proposal-import-conditions/issues/24) and [#25](https://github.com/tc39/proposal-import-conditions/issues/25)).
+Standardization here would consist of building consensus not just in TC39 but also in WHATWG HTML as well as the Node.js ESM effort and a general audit of semantic requirements across various host environments ([#10](https://github.com/tc39/proposal-import-assertions/issues/10), [#24](https://github.com/tc39/proposal-import-assertions/issues/24) and [#25](https://github.com/tc39/proposal-import-assertions/issues/25)).
 
 ## Specification
 
-* [Specification Outline](https://tc39.es/proposal-import-conditions/)
+* [Specification Outline](https://tc39.es/proposal-import-assertions/)
 * [Pull Request for HTML spec integration](https://github.com/whatwg/html/pull/5658)

--- a/spec.html
+++ b/spec.html
@@ -2,9 +2,9 @@
 <meta charset="utf8">
 <script src="ecmarkup.js"></script>
 <link rel="stylesheet" href="ecmarkup.css">
-<title>import conditions</title>
+<title>import assertions</title>
 <pre class=metadata>
-  title: Import conditions
+  title: Import assertions
   status: proposal
   stage: 2
   location: https://github.com/tc39/proposal-import-conditions
@@ -12,7 +12,7 @@
   contributors: Sven Sauleau, Myles Borins, Daniel Ehrenberg, Daniel Clark
 </pre>
 <emu-intro id="intro">
-  <h1>import conditions</h1>
+  <h1>import assertions</h1>
   <p>See <a href="https://github.com/tc39/proposal-import-conditions/blob/master/README.md">the explainer</a> for information.</p>
 </emu-intro>
 
@@ -72,7 +72,7 @@
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
           1. Let _specifierString_ be ToString(_specifier_).
           1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
-          1. <ins>Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Conditions]]: an empty List }.</ins>
+          1. <ins>Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Assertions]]: an empty List }.</ins>
           1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, <del>_specifierString_,</del> <ins>_moduleRequest_,</ins> _promiseCapability_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
@@ -87,18 +87,18 @@
           1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
           1. <ins>Let _argRef_ be the result of evaluating the second |AssignmentExpression|.</ins>
           1. <ins>Let _arg_ be ? GetValue(_argRef_).</ins>
-          1. <ins>If _arg_ is *undefined*, let _conditions_ be an empty List.</ins>
+          1. <ins>If _arg_ is *undefined*, let _assertions_ be an empty List.</ins>
           1. <ins>Otherwise,</ins>
-            1. <ins>Let _conditionsObj_ be ? Get(_arg_, *"assert"*).</ins>
-            1. <ins>Let _conditions_ be a new empty List.</ins>
-            1. <ins>Let _keys_ be EnumerableOwnPropertyNames(_conditionsObj_, ~key~).</ins>
+            1. <ins>Let _assertionsObj_ be ? Get(_arg_, *"assert"*).</ins>
+            1. <ins>Let _assertions_ be a new empty List.</ins>
+            1. <ins>Let _keys_ be EnumerableOwnPropertyNames(_assertionsObj_, ~key~).</ins>
             1. <ins>IfAbruptRejectPromise(_keys_, _promiseCapability_).</ins>
             1. <ins>For each String _key_ of _keys_,</ins>
-              1. <ins>Let _value_ be Get(_conditionsObj_, _key_).</ins>
+              1. <ins>Let _value_ be Get(_assertionsObj_, _key_).</ins>
               1. <ins>IfAbruptRejectPromise(_value_, _promiseCapability_).</ins>
-              1. <ins>Append { [[Key]]: _key_, [[Value]], _value_ } to _conditions_.</ins>
-            1. <ins>Sort _conditions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among conditions by the order they occur in.</ens>
-          1. <ins>Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Conditions]]: _conditions_ }.</ins>
+              1. <ins>Append { [[Key]]: _key_, [[Value]], _value_ } to _assertions_.</ins>
+            1. <ins>Sort _assertions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among assertions by the order they occur in.</ens>
+          1. <ins>Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Assertions]]: _assertions_ }.</ins>
           1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, <del>_specifierString_,</del> <ins>_moduleRequest_,</ins> _promiseCapability_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
@@ -129,11 +129,11 @@
             Each time this operation is called with a specific _referencingScriptOrModule_, <del>_specifier_,</del> <ins>_moduleRequest_.[[Specifier]]</ins> pair as arguments it must return the same Module Record instance if it completes normally.
           </li>
           <li>
-            <ins>_moduleRequest_.[[Conditions]] must not influence the interpretation of the module or the module specifier; instead, it may be used to determine whether the algorithm completes normally or with an abrupt completion.</ins>
+            <ins>_moduleRequest_.[[Assertions]] must not influence the interpretation of the module or the module specifier; instead, it may be used to determine whether the algorithm completes normally or with an abrupt completion.</ins>
           </li>
           <li>
             <ins>
-              If _conditions_ has an entry _entry_ such that _entry_.[[Key]] is *"type"*, let _type_ be _entry_.[[Value]]. The following requirements apply:
+              If _assertions_ has an entry _entry_ such that _entry_.[[Key]] is *"type"*, let _type_ be _entry_.[[Value]]. The following requirements apply:
               <ul>
                 <li><ins>If _type_ is *"json"*, then this algorithm must either invoke ParseJSONModule and return the resulting Module Record, or throw an exception.</ins></li>
               </ul>
@@ -143,8 +143,8 @@
         <p>Multiple different _referencingScriptOrModule_, <del>_specifier_</del> <ins>_moduleRequest_.[[Specifier]]</ins> pairs may map to the same Module Record instance. The actual mapping semantic is implementation-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as alphabetic case folding and expansion of relative and abbreviated path specifiers.</p>
 
         <emu-note type=editor>
-          <p>The above text implies that, if a module is imported multiple times with different _moduleRequest_.[[Conditions]] values, then there can be just one possible "successful" value (possibly as a result of multiple different conditions), but that it can also fail with an exception thrown; this exception from one import does not rule out success with a different condition list.</p>
-          <p>Conditions do not affect the contents of the module or be part of the cache key. Future follow-up proposals may relax this restriction with "evaluator attributes" that would change the contents of the module. There are three possible ways to handle multiple imports of the same module with "evaluator attributes":</p>
+          <p>The above text implies that, if a module is imported multiple times with different _moduleRequest_.[[Assertions]] values, then there can be just one possible "successful" value (possibly as a result of multiple different assertions), but that it can also fail with an exception thrown; this exception from one import does not rule out success with a different assertion list.</p>
+          <p>Assertions do not affect the contents of the module or be part of the cache key. Future follow-up proposals may relax this restriction with "evaluator attributes" that would change the contents of the module. There are three possible ways to handle multiple imports of the same module with "evaluator attributes":</p>
           <ul>
             <li><strong>Race</strong> and use the attribute that was requested by the first import. This seems broken--the second usage is ignored.</li>
             <li><strong>Reject</strong> the module graph and don't load if attributes differ. This seems bad for composition--using two unrelated packages together could break, if they load the same module with disagreeing attributes.</li>
@@ -391,9 +391,9 @@
     <h1>Runtime Semantics: AssertClauseToConditions</h1>
     <emu-grammar>AssertClause : `assert` `{` ConditionEntries `,`? `}`</emu-grammar>
     <emu-alg>
-      1. Let _conditions_ be AssertClauseToConditions of |ConditionEntries|.
-      1. Sort _conditions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among conditions by the order they occur in.
-      1. Return _conditions_.
+      1. Let _assertions_ be AssertClauseToConditions of |ConditionEntries|.
+      1. Sort _assertions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among assertions by the order they occur in.
+      1. Return _assertions_.
     </emu-alg>
 
     <emu-grammar> ConditionEntries : ConditionKey `:` StringLiteral </emu-grammar>
@@ -423,7 +423,7 @@
       <emu-clause id="sec-modulerequest-record">
         <h1>ModuleRequest Records</h1>
 
-        <p>A <dfn>ModuleRequest Record</dfn> represents the request to import a module with given import conditions. It consists of the following fields:</p>
+        <p>A <dfn>ModuleRequest Record</dfn> represents the request to import a module with given import assertions. It consists of the following fields:</p>
         <emu-table id="table-cyclic-module-fields" caption="ModuleRequest Record fields">
           <table>
             <tbody>
@@ -451,13 +451,13 @@
               </tr>
               <tr>
                 <td>
-                  [[Conditions]]
+                  [[Assertions]]
                 </td>
                 <td>
                   a List of Records { [[Key]]: a String, [[Value]]: a String }
                 </td>
                 <td>
-                  The import conditions
+                  The import assertions
                 </td>
               </tr>
             </tbody>
@@ -534,7 +534,7 @@
                   List of <del>String</del><ins>ModuleRequest Record</ins>
                 </td>
                 <td>
-                  A List of all the |ModuleSpecifier| strings <ins>and import conditions</ins> used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
+                  A List of all the |ModuleSpecifier| strings <ins>and import assertions</ins> used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
                 </td>
               </tr>
             </tbody>
@@ -566,7 +566,7 @@
               </td>
               <td>
                 <del>String value of the |ModuleSpecifier| of the |ImportDeclaration|.</del>
-                <ins>ModuleRequest Record representing the |ModuleSpecifier| and import conditions of the |ImportDeclaration|.</ins>
+                <ins>ModuleRequest Record representing the |ModuleSpecifier| and import assertions of the |ImportDeclaration|.</ins>
               </td>
             </tr>
             <tr>
@@ -602,13 +602,13 @@
         <emu-alg>
           1. <del>Return ModuleRequests of |FromClause|.</del>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Conditions]]: an empty List }.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Assertions]]: an empty List }.</ins>
         </emu-alg>
         <emu-grammar>ImportDeclaration : `import` ImportClause FromClause AssertClause `;`</emu-grammar>
         <emu-alg>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Let _conditions_ be AssertClauseToConditions of |AssertClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Conditions]]: _conditions_ }.</ins>
+          1. <ins>Let _assertions_ be AssertClauseToConditions of |AssertClause|.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Assertions]]: _assertions_ }.</ins>
         </emu-alg>
         <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
@@ -625,7 +625,7 @@
           1. Append to _moduleNames_ each element of _additionalNames_ <del>that is not already an element of _moduleNames_</del>.
           1. Return _moduleNames_.
         </emu-alg>
-        <emu-note type=editor>Deletion of duplicates is an unnecessary "spec optimization" that would be more complicated to explain in terms of examining import condition records, and can be simply removed.</emu-note>
+        <emu-note type=editor>Deletion of duplicates is an unnecessary "spec optimization" that would be more complicated to explain in terms of examining import assertion records, and can be simply removed.</emu-note>
         <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
@@ -636,15 +636,15 @@
         <emu-alg>
           1. <del>Return ModuleRequests of |FromClause|.</del>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Conditions]]: an empty List }.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Assertions]]: an empty List }.</ins>
         </emu-alg>
         <emu-grammar>
           ExportDeclaration : `export` ExportFromClause FromClause AssertClause `;`
         </emu-grammar>
         <emu-alg>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Let _conditions_ be AssertClauseToConditions of |AssertClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Conditions]]: _conditions_ }.</ins>
+          1. <ins>Let _assertions_ be AssertClauseToConditions of |AssertClause|.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Assertions]]: _assertions_ }.</ins>
         </emu-alg>
         <emu-grammar>
           ExportDeclaration :
@@ -664,21 +664,21 @@
 <emu-annex id="sec-host-integration">
   <h1>Sample host integration: The Web embedding</h1>
 
-  <p>The import conditions proposal is intended to give key information about how modules are interpreted to hosts. For the Web embedding and environments which aim to be similar to it, the string is interpreted as the "module type". This is not the primary way the module type is determined (which, on the Web, would be the MIME type, and in other environments may be the file extension), but rather a secondary check which is required to pass for the module graph to load.</p>
+  <p>The import assertions proposal is intended to give key information about how modules are interpreted to hosts. For the Web embedding and environments which aim to be similar to it, the string is interpreted as the "module type". This is not the primary way the module type is determined (which, on the Web, would be the MIME type, and in other environments may be the file extension), but rather a secondary check which is required to pass for the module graph to load.</p>
 
-  <p>In the Web embedding, the following changes would be made to the HTML specification for import conditions:</p>
+  <p>In the Web embedding, the following changes would be made to the HTML specification for import assertions:</p>
 
   <ul>
     <li>The <a href="https://html.spec.whatwg.org/#module-script">module script</a> would have an additional item, which would be the module type, as a string (e.g., *"json"*), or *undefined* for a JavaScript module.</li>
-    <li>HostResolveImportedModule and HostImportModuleDynamically would take a ModuleRequest Record parameter in place of a specifier string, which would be passed down through several abstract operations to reach the <a href="https://html.spec.whatwg.org/#fetch-a-single-module-script">fetch a single module script</a> algorithm. Somewhere near the entrypoint, if the ModuleRequest Record's [[Conditions]] field has an entry _entry_ such that _entry_.[[Key]] is *"type"*, then let _type_ be _entry_.[[Value]]; otherwise let _type_ be *undefined*. If the type is invalid, then an exception is thrown and module loading fails. Otherwise, this will equal the module type, if the module can be successfully fetched with a matching MIME type.</li>
-    <li>In the <a href="https://html.spec.whatwg.org/#fetch-the-descendants-of-a-module-script">fetch the descendents of a module script</a> algorithm, when iterating over [[RequestedModules]], the elements are ModuleRequest Records rather than just specifier strings; these Records is passed on to the internal module script graph fetching procedure (which sends it to "fetch a single module script". Other usage sites of [[RequestedModules]] ignore the condition.</li>
-    <li>"Fetch a single module script" would check the condition in two places:
+    <li>HostResolveImportedModule and HostImportModuleDynamically would take a ModuleRequest Record parameter in place of a specifier string, which would be passed down through several abstract operations to reach the <a href="https://html.spec.whatwg.org/#fetch-a-single-module-script">fetch a single module script</a> algorithm. Somewhere near the entrypoint, if the ModuleRequest Record's [[Assertions]] field has an entry _entry_ such that _entry_.[[Key]] is *"type"*, then let _type_ be _entry_.[[Value]]; otherwise let _type_ be *undefined*. If the type is invalid, then an exception is thrown and module loading fails. Otherwise, this will equal the module type, if the module can be successfully fetched with a matching MIME type.</li>
+    <li>In the <a href="https://html.spec.whatwg.org/#fetch-the-descendants-of-a-module-script">fetch the descendents of a module script</a> algorithm, when iterating over [[RequestedModules]], the elements are ModuleRequest Records rather than just specifier strings; these Records is passed on to the internal module script graph fetching procedure (which sends it to "fetch a single module script". Other usage sites of [[RequestedModules]] ignore the assertion.</li>
+    <li>"Fetch a single module script" would check the assertion in two places:
       <ul>
-        <li>If the module is found in the module map, then _type_ is checked against he module script's type field. If they differ, then an exception is thrown and module loading fails.</li>
+        <li>If the module is found in the module map, then _type_ is checked against the module script's type field. If they differ, then an exception is thrown and module loading fails.</li>
         <li>When a new module is fetched, before writing it into the module map, the MIME type is checked to ensure that it matches _type_. (Note that the interpretation of the module is still driven by the MIME type, but once the MIME type is established, this is checked against the _type_.) If they differ, then an exception is thrown and module loading fails. The _type_ is written into the module script as the type.</li>
       </ul>
     </li>
   </ul>
 
-  <p>Note that the module map remains keyed by the absolute URL; the _type_ is not part of the module map key, and initially, no other import conditions are supported, so they are also not present.</p>
+  <p>Note that the module map remains keyed by the absolute URL; the _type_ is not part of the module map key, and initially, no other import assertions are supported, so they are also not present.</p>
 </emu-annex>

--- a/spec.html
+++ b/spec.html
@@ -37,13 +37,13 @@
       `export` `default` [lookahead &lt;! {`function`, `async` [no |LineTerminator| here] `function`, `class`}] AssignmentExpression[+In, ~Yield, ~Await] `;`
 
     AssertClause :
-      <ins>`assert` `{` ConditionEntries `,`? `}`</ins>
+      <ins>`assert` `{` AssertEntries `,`? `}`</ins>
 
-    ConditionEntries :
-      <ins>ConditionKey `:` StringLiteral</ins>
-      <ins>ConditionKey `:` StringLiteral `,` ConditionEntries</ins>
+    AssertEntries :
+      <ins>AssertionKey `:` StringLiteral</ins>
+      <ins>AssertionKey `:` StringLiteral `,` AssertEntries</ins>
 
-    ConditionKey:
+    AssertionKey:
       <ins>IdentifierName</ins>
       <ins>StringLiteral</ins>
 
@@ -381,40 +381,40 @@
 
   <emu-clause id="sec-assert-clause-early-errors">
     <h1>Static Semantics: Early Errors</h1>
-    <emu-grammar>AssertClause : `assert` `{` ConditionEntries `,`? `}`</emu-grammar>
+    <emu-grammar>AssertClause : `assert` `{` AssertEntries `,`? `}`</emu-grammar>
     <ul>
-      <li>It is a Syntax Error if AssertClauseToConditions of |AssertClause| has two entries _a_ and _b_ such that _a_.[[Key]] is _b_.[[Key]].</li>
+      <li>It is a Syntax Error if AssertClauseToAssertions of |AssertClause| has two entries _a_ and _b_ such that _a_.[[Key]] is _b_.[[Key]].</li>
     </ul>
   </emu-clause>
 
-  <emu-clause id="sec-assert-clause-to-conditions" aoid="AssertClauseToConditions">
-    <h1>Runtime Semantics: AssertClauseToConditions</h1>
-    <emu-grammar>AssertClause : `assert` `{` ConditionEntries `,`? `}`</emu-grammar>
+  <emu-clause id="sec-assert-clause-to-assertions" aoid="AssertClauseToAssertions">
+    <h1>Runtime Semantics: AssertClauseToAssertions</h1>
+    <emu-grammar>AssertClause : `assert` `{` AssertEntries `,`? `}`</emu-grammar>
     <emu-alg>
-      1. Let _assertions_ be AssertClauseToConditions of |ConditionEntries|.
+      1. Let _assertions_ be AssertClauseToAssertions of |AssertEntries|.
       1. Sort _assertions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among assertions by the order they occur in.
       1. Return _assertions_.
     </emu-alg>
 
-    <emu-grammar> ConditionEntries : ConditionKey `:` StringLiteral </emu-grammar>
+    <emu-grammar> AssertEntries : AssertionKey `:` StringLiteral </emu-grammar>
     <emu-alg>
-      1. Let _entry_ be a Record { [[Key]]: AssertClauseToConditions of |ConditionKey|, [[Value]]: StringValue of |StringLiteral| }.
+      1. Let _entry_ be a Record { [[Key]]: AssertClauseToAssertions of |AssertionKey|, [[Value]]: StringValue of |StringLiteral| }.
       1. Return a new List containing the single element, _entry_.
     </emu-alg>
 
-    <emu-grammar> ConditionEntries : ConditionKey `:` StringLiteral `,` ConditionEntries </emu-grammar>
+    <emu-grammar> AssertEntries : AssertionKey `:` StringLiteral `,` AssertEntries </emu-grammar>
     <emu-alg>
-      1. Let _entry_ be a Record { [[Key]]: AssertClauseToConditions of |ConditionKey|, [[Value]]: StringValue of |StringLiteral| }.
-      1. Let _rest_ be AssertClauseToConditions of |ConditionEntries|.
+      1. Let _entry_ be a Record { [[Key]]: AssertClauseToAssertions of |AssertionKey|, [[Value]]: StringValue of |StringLiteral| }.
+      1. Let _rest_ be AssertClauseToAssertions of |AssertEntries|.
       1. Return a new List containing _entry_ followed by the entries of _rest_.
     </emu-alg>
 
-    <emu-grammar> ConditionKey : IdentifierName </emu-grammar>
+    <emu-grammar> AssertionKey : IdentifierName </emu-grammar>
     <emu-alg>
       1. Return the StringValue of |IdentifierName|.
     </emu-alg>
 
-    <emu-grammar> ConditionKey : StringLiteral </emu-grammar>
+    <emu-grammar> AssertionKey : StringLiteral </emu-grammar>
     <emu-alg>
       1. Return the StringValue of |StringLiteral|.
     </emu-alg>
@@ -607,7 +607,7 @@
         <emu-grammar>ImportDeclaration : `import` ImportClause FromClause AssertClause `;`</emu-grammar>
         <emu-alg>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Let _assertions_ be AssertClauseToConditions of |AssertClause|.</ins>
+          1. <ins>Let _assertions_ be AssertClauseToAssertions of |AssertClause|.</ins>
           1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Assertions]]: _assertions_ }.</ins>
         </emu-alg>
         <emu-grammar>Module : [empty]</emu-grammar>
@@ -643,7 +643,7 @@
         </emu-grammar>
         <emu-alg>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Let _assertions_ be AssertClauseToConditions of |AssertClause|.</ins>
+          1. <ins>Let _assertions_ be AssertClauseToAssertions of |AssertClause|.</ins>
           1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Assertions]]: _assertions_ }.</ins>
         </emu-alg>
         <emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -7,13 +7,13 @@
   title: Import assertions
   status: proposal
   stage: 2
-  location: https://github.com/tc39/proposal-import-conditions
+  location: https://github.com/tc39/proposal-import-assertions
   copyright: false
   contributors: Sven Sauleau, Myles Borins, Daniel Ehrenberg, Daniel Clark
 </pre>
 <emu-intro id="intro">
   <h1>import assertions</h1>
-  <p>See <a href="https://github.com/tc39/proposal-import-conditions/blob/master/README.md">the explainer</a> for information.</p>
+  <p>See <a href="https://github.com/tc39/proposal-import-assertions/blob/master/README.md">the explainer</a> for information.</p>
 </emu-intro>
 
 <emu-clause id="sec-syntax">


### PR DESCRIPTION
Finish the rename to 'import assertions' started in 3d716696f0685ba086beac7da57a62f42f5ede2e by updating all remaining references from 'condition' to 'assertion' in the README and the spec text.