### PR TITLE
Relax restriction forbidding hosts from using import assertions in cache key

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -148,7 +148,7 @@
         <p>Multiple different _referencingScriptOrModule_, <del>_specifier_</del> <ins>_moduleRequest_.[[Specifier]]</ins> pairs may map to the same Module Record instance. The actual mapping semantic is implementation-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as alphabetic case folding and expansion of relative and abbreviated path specifiers.</p>
 
         <emu-note type=editor>
-          <p>The above text implies that is recommended but not required that hosts do not consider _moduleRequest_.[[Assertions]] as part of the module cache key. In either case, an exception thrown from an import with a given assertion list does not rule out success of another import with the same specifier but a different assertion list.</p>
+          <p>The above text implies that is recommended but not required that hosts do not use _moduleRequest_.[[Assertions]] as part of the module cache key. In either case, an exception thrown from an import with a given assertion list does not rule out success of another import with the same specifier but a different assertion list.</p>
           <p>Assertions do not affect the contents of the module. Future follow-up proposals may relax this restriction with "evaluator attributes" that would change the contents of the module. There are three possible ways to handle multiple imports of the same module with "evaluator attributes":</p>
           <ul>
             <li><strong>Race</strong> and use the attribute that was requested by the first import. This seems broken--the second usage is ignored.</li>

--- a/spec.html
+++ b/spec.html
@@ -126,7 +126,12 @@
             If a Module Record corresponding to the pair _referencingScriptOrModule_, <del>_specifier_</del>, <ins>_moduleRequest_</ins> does not exist or cannot be created, an exception must be thrown.
           </li>
           <li>
-            Each time this operation is called with a specific _referencingScriptOrModule_, <del>_specifier_,</del> <ins>_moduleRequest_.[[Specifier]]</ins> pair as arguments it must return the same Module Record instance if it completes normally.
+            Each time this operation is called with a specific _referencingScriptOrModule_, <del>_specifier_ pair</del> <ins>_moduleRequest_.[[Specifier]], _moduleRequest_.[[Assertions]] triple</ins> as arguments it must return the same Module Record instance if it completes normally.
+            <ul>
+              <li>
+                It is recommended but not required that implementations additionally conform to the following stronger constraint: each time this operation is called with a specific _referencingScriptOrModule_, _moduleRequest_.[[Specifier]] pair as arguments it must return the same Module Record instance if it completes normally.
+              </li>
+            </ul>
           </li>
           <li>
             <ins>_moduleRequest_.[[Assertions]] must not influence the interpretation of the module or the module specifier; instead, it may be used to determine whether the algorithm completes normally or with an abrupt completion.</ins>
@@ -143,8 +148,8 @@
         <p>Multiple different _referencingScriptOrModule_, <del>_specifier_</del> <ins>_moduleRequest_.[[Specifier]]</ins> pairs may map to the same Module Record instance. The actual mapping semantic is implementation-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as alphabetic case folding and expansion of relative and abbreviated path specifiers.</p>
 
         <emu-note type=editor>
-          <p>The above text implies that, if a module is imported multiple times with different _moduleRequest_.[[Assertions]] values, then there can be just one possible "successful" value (possibly as a result of multiple different assertions), but that it can also fail with an exception thrown; this exception from one import does not rule out success with a different assertion list.</p>
-          <p>Assertions do not affect the contents of the module or be part of the cache key. Future follow-up proposals may relax this restriction with "evaluator attributes" that would change the contents of the module. There are three possible ways to handle multiple imports of the same module with "evaluator attributes":</p>
+          <p>The above text implies that is recommended but not required that hosts do not consider _moduleRequest_.[[Assertions]] as part of the module cache key. In either case, an exception thrown from an import with a given assertion list does not rule out success of another import with the same specifier but a different assertion list.</p>
+          <p>Assertions do not affect the contents of the module. Future follow-up proposals may relax this restriction with "evaluator attributes" that would change the contents of the module. There are three possible ways to handle multiple imports of the same module with "evaluator attributes":</p>
           <ul>
             <li><strong>Race</strong> and use the attribute that was requested by the first import. This seems broken--the second usage is ignored.</li>
             <li><strong>Reject</strong> the module graph and don't load if attributes differ. This seems bad for composition--using two unrelated packages together could break, if they load the same module with disagreeing attributes.</li>


### PR DESCRIPTION
As agreed on at the July TC39 meeting, relax the constraint that had banned hosts from using ModuleRequest.[[Assertions]] as part of the cache key.  Still recommend, however, that they do not do so, though we know that the HTML integration will go against this recommendation in https://github.com/whatwg/html/pull/5658.   Continue requiring that [[Assertions]] do not affect the interpretation of the module.