### PR TITLE
Handle move of JSON modules to separate proposal

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -136,14 +136,6 @@
           <li>
             <ins>_moduleRequest_.[[Assertions]] must not influence the interpretation of the module or the module specifier; instead, it may be used to determine whether the algorithm completes normally or with an abrupt completion.</ins>
           </li>
-          <li>
-            <ins>
-              If _assertions_ has an entry _entry_ such that _entry_.[[Key]] is *"type"*, let _type_ be _entry_.[[Value]]. The following requirements apply:
-              <ul>
-                <li><ins>If _type_ is *"json"*, then this algorithm must either invoke ParseJSONModule and return the resulting Module Record, or throw an exception.</ins></li>
-              </ul>
-            </ins>
-          </li>
         </ul>
         <p>Multiple different _referencingScriptOrModule_, <del>_specifier_</del> <ins>_moduleRequest_.[[Specifier]]</ins> pairs may map to the same Module Record instance. The actual mapping semantic is implementation-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as alphabetic case folding and expansion of relative and abbreviated path specifiers.</p>
 
@@ -156,14 +148,6 @@
             <li><strong>Clone</strong> and make two copies of the module, for the different ways it's transformed. In this case, the attributes would have to be part of the cache key. These semantics would run counter to the intuition that there is just one copy of a module.</li>
           </ul>
           <p>It's possible that one of these three options may make sense for a module load, on a case-by-case basis by attribute, but it's worth careful thought before making this choice.</p>
-        </emu-note>
-
-        <emu-note type=editor>
-          <p>The above text implies that hosts *must* support JSON modules imported with `type: "json"` (if it completes normally), but it doesn't prohibit hosts from supporting JSON modules imported with no type specified. Some environments (for example, web browsers) are expected to require `if { type: "json" }`, and environments which want to restrict themselves to a compatible subset would do so as well.</p>
-        </emu-note>
-
-        <emu-note type=editor>
-          <p>All of the import statements in the module graph that address the same JSON module will evaluate to the same mutable object.</p>
         </emu-note>
       </emu-clause>
 
@@ -229,160 +213,6 @@
             1. Else, perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _namespace_.[[Value]] »).
         </emu-alg>
       </emu-clause>
-
-      <emu-clause id="sec-synthetic-module-records">
-        <h1>Synthetic Module Records</h1>
-
-        <emu-note type="editor">This Synthetic Module Records specification text comes from the <a href="github.com/tc39/proposal-javascript-standard-library/">JavaScript Standard Library proposal</a> and was written by Domenic Denicola. A version of this text exists <a href="https://heycam.github.io/webidl/#synthetic-module-records">in WebIDL</a>. A version of the text is copied here to clarify that the concept of Synthetic Module Records can proceed in standardization independently of the built-in modules effort.</emu-note>
-
-        <p>A <dfn>Synthetic Module Record</dfn> is used to represent information about a module that is defined by specifications. Its exports are derived from a pair of lists, of string keys and of ECMAScript values. The set of exported names is static, and determined at creation time (as an argument to CreateSyntheticModule), while the set of exported values can be changed over time using SetSyntheticModuleExport. It has no imports or dependencies.</p>
-
-        <emu-note>A Synthetic Module Record could be used for defining a variety of module types: for example, built-in modules, or JSON modules, or CSS modules.</emu-note>
-
-        <p>In addition to the fields defined in <emu-xref href="#table-36"></emu-xref>, Synthetic Module Records have the additional fields listed in <emu-xref href="#table-synthetic-module-record-fields"></emu-xref>. Each of these fields is initially set in CreateSyntheticModule.</p>
-
-        <emu-table id="table-synthetic-module-record-fields" caption="Additional Fields of Synthetic Module Records">
-          <table>
-            <thead>
-              <th>Field Name
-              <th>Value Type
-              <th>Meaning
-            </thead>
-            <tbody>
-              <tr>
-                <td>[[ExportNames]]
-                <td>List of String
-                <td>A List of all names that are exported.
-              </tr>
-              <tr>
-                <td>[[EvaluationSteps]]
-                <td>An abstract operation
-                <td>An abstract operation that will be performed upon evaluation of the module, taking the Synthetic Module Record as its sole argument. These will usually set up the exported values, by using SetSyntheticModuleExport. They must not modify [[ExportNames]]. They may return an abrupt completion.
-              </tr>
-            </tbody>
-          </table>
-        </emu-table>
-
-        <emu-clause id="sec-createsyntheticmodule" aoid="CreateSyntheticModule">
-          <h1>CreateSyntheticModule ( _exportNames_, _evaluationSteps_, _realm_, _hostDefined_ )</h1>
-
-          <p>The abstract operation CreateSyntheticModule creates a Synthetic Module Record based upon the given exported names and evaluation steps. It performs the following steps:</p>
-
-          <emu-alg>
-            1. Return Synthetic Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ExportNames]]: _exportNames_, [[EvaluationSteps]]: _evaluationSteps_ }.
-          </emu-alg>
-
-          <emu-note type="editor">It seems we could set up the environment either here or in Instantiate(). I've chosen to do so in Instantiate() for symmetry with Source Text Module Records, but I don't think there's any actual requirement in that regard.</emu-note>
-        </emu-clause>
-
-        <emu-clause id="sec-setsyntheticmoduleexport" aoid="SetSyntheticModuleExport">
-          <h1>SetSyntheticModuleExport ( _module_, _exportName_, _exportValue_ )</h1>
-
-          <p>The abstract operation SetSyntheticModuleExport can be used to set or change the exported value for a pre-established export of a Synthetic Module Record. It performs the following steps:</p>
-
-          <emu-alg>
-            1. Let _envRec_ be _module_.[[Environment]]'s EnvironmentRecord.
-            1. Perform _envRec_.SetMutableBinding(_exportName_, _exportValue_, *true*).
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-smr-concrete-methods">
-          <h1>Concrete Methods</h1>
-
-          <p>The following are the concrete methods for Synthetic Module Record that implement the corresponding Module Record abstract methods.</p>
-
-          <emu-note type="editor">I find having this wrapping sub-clause cleaner and suggest we do the same for Source Text Module Records in the main spec.</emu-note>
-
-          <emu-clause id="sec-smr-getexportednames">
-            <h1>GetExportedNames( _exportStarSet_ )</h1>
-
-            <p>The GetExportedNames concrete method of a Synthetic Module Record implements the corresponding Module Record abstract method.</p>
-            <p>It performs the following steps:</p>
-
-            <emu-alg>
-              1. Let _module_ be this Synthetic Module Record.
-              1. Return _module_.[[ExportNames]].
-            </emu-alg>
-          </emu-clause>
-
-          <emu-clause id="sec-smr-resolveexport">
-            <h1>ResolveExport( _exportName_, _resolveSet_ )</h1>
-
-            <p>The ResolveExport concrete method of a Synthetic Module Record implements the corresponding Module Record abstract method.</p>
-            <p>It performs the following steps:</p>
-
-            <emu-alg>
-              1. Let _module_ be this Synthetic Module Record.
-              1. If _module_.[[ExportNames]] does not contain _exportName_, return null.
-              1. Return ResolvedBinding Record { [[Module]]: _module_, [[BindingName]]: _exportName_ }.
-            </emu-alg>
-          </emu-clause>
-
-          <emu-clause id="sec-smr-instantiate">
-            <h1>Instantiate ( )</h1>
-
-            <p>The Instantiate concrete method of a Synthetic Module Record implements the corresponding Module Record abstract method.</p>
-            <p>It performs the following steps:</p>
-
-            <emu-alg>
-              1. Let _module_ be this Synthetic Module Record.
-              1. Let _realm_ be _module_.[[Realm]].
-              1. Assert: _realm_ is not *undefined*.
-              1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
-              1. Set _module_.[[Environment]] to _env_.
-              1. Let _envRec_ be _env_'s EnvironmentRecord.
-              1. For each _exportName_ in _module_.[[ExportNames]],
-              1. Perform ! _envRec_.CreateMutableBinding(_exportName_, *false*).
-              1. Perform ! _envRec_.InitializeBinding(_exportName_, *undefined*).
-              1. Return *undefined*.
-            </emu-alg>
-          </emu-clause>
-
-          <emu-clause id="sec-smr-Evaluate">
-            <h1>Evaluate ( )</h1>
-
-            <p>The Evaluate concrete method of a Synthetic Module Record implements the corresponding Module Record abstract method.</p>
-            <p>It performs the following steps:</p>
-
-            <emu-alg>
-              1. Let _module_ be this Synthetic Module Record.
-              1. Let _moduleCxt_ be a new ECMAScript code execution context.
-              1. Set the Function of _moduleCxt_ to *null*.
-              1. Assert: _module_.[[Realm]] is not *undefined*.
-              1. Set the Realm of _moduleCxt_ to _module_.[[Realm]].
-              1. Set the ScriptOrModule of _moduleCxt_ to _module_.
-              1. Set the VariableEnvironment of _moduleCxt_ to _module_.[[Environment]].
-              1. Set the LexicalEnvironment of _moduleCxt_ to _module_.[[Environment]].
-              1. Suspend the currently running execution context.
-              1. Push _moduleCxt_ on to the execution context stack; _moduleCxt_ is now the running execution context.
-              1. Let _result_ be the result of performing ? _module_.[[EvaluationSteps]](_module_).
-              1. Suspend _moduleCxt_ and remove it from the execution context stack.
-              1. Resume the context that is now on the top of the execution context stack as the running execution context.
-              1. Return Completion(_result_).
-            </emu-alg>
-          </emu-clause>
-        </emu-clause>
-      </emu-clause>
-
-  <emu-clause id="sec-create-default-export-synthetic-module" aoid="CreateDefaultExportSyntheticModule">
-    <h1>CreateDefaultExportSyntheticModule ( _defaultExport_ )</h1>
-    <p>The CreateDefaultExportSyntheticModule abstract operation creates a Synthetic Module Record whose default export is _defaultExport_. It performs the following steps:</p>
-    <emu-alg>
-      1. Return CreateSyntheticModule(&laquo; *"default"* &raquo;, the following steps, the current Realm, _defaultExport_) with the following steps given _module_ as an argument:</p>
-        1. SetSyntheticModuleExport(_module_, *"default"*, _module_.[[HostDefined]]).</li>
-    </emu-alg>
-    <!-- TODO: Could we apply the new spec closure concept here rather than painstakingly passing _defaultExport_ through [[HostDefined]]? -->
-  </emu-clause>
-
-  <emu-clause id="sec-parse-json-module" aoid="ParseJSONModule">
-    <h1>ParseJSONModule ( _source_ )</h1>
-    <p>The abstract operation ParseJSONModule takes a single argument _source_ which is a String representing the contents of a module.</p>
-
-    <emu-alg>
-      1. Let _json_ be ? Call(%JSONParse%, *undefined*, « _source_ »).  <!-- TODO: Refactor JSONParse into an abstract algorithm -->
-      1. Return CreateDefaultExportSyntheticModule(_json_).
-    </emu-alg>
-  </emu-clause>
 
   <emu-clause id="sec-assert-clause-early-errors">
     <h1>Static Semantics: Early Errors</h1>

--- a/tag-security-and-privacy.md
+++ b/tag-security-and-privacy.md
@@ -13,7 +13,7 @@ Yes.
 
 ## 2.3. How does this specification deal with personal information or personally-identifiable information or information derived thereof?
 
-HTML imports modules by performing fetches from the URL indicated in the module specifier. JavaScript code may construct a URL exposing personally identifying information which is implicitly communicated by importing a particular kind of JSON module, but this is already possible with JS modules.
+HTML imports modules by performing fetches from the URL indicated in the module specifier. JavaScript code may construct a URL exposing personally identifying information which is implicitly communicated by importing a module with that URL, but this is already possible with JS modules.
 
 No new identifying information is communicated by this proposal.
 
@@ -27,7 +27,7 @@ No.
 
 ## 2.6. What information from the underlying platform, e.g. configuration data, is exposed by this specification to an origin?
 
-Regardless of the conclusion of 2.1 about exposing the type to the origin; if a host implements this proposal, JSON modules must be supported.
+None.
 
 ## 2.7. Does this specification allow an origin access to sensors on a user’s device
 
@@ -41,7 +41,7 @@ No data.
 
 This proposal will enable future module types on the web, first JSON module and then HTML, CSS, ...
 
-The type attribute is designed to let the importer specify whether the imported module has the capability to execute code: some module types are able to execute code, while others are not.
+This will be done via the `type` attribute, which is designed to let the importer specify whether the imported module has the capability to execute code: some module types are able to execute code, while others are not.
 
 ## 2.10. Does this specification allow an origin to access other devices?
 
@@ -57,7 +57,7 @@ No identifiers.
 
 ## 2.13. How does this specification distinguish between behavior in first-party and third-party contexts?
 
-This specification allows importing more kinds of cross-origin subresources (initially, JSON documents) as modules, analogous to how ES modules work. The imported subresource is not distinguished and generally treated as "first-party", but the explicit use of type avoids giving this subresource unnecessary capabilities (including both executing code and accessing parsers).
+This specification allows importing more kinds of cross-origin subresources as modules, analogous to how ES modules work. The imported subresources are not distinguished and generally treated as "first-party", but each new subresource types will be importable only with the explicit use of a `type` assertion, which avoids giving the subresource unnecessary capabilities (including both executing code and accessing parsers).
 
 ## 2.14. How does this specification work in the context of a user agent’s Private Browsing or "incognito" mode?
 


### PR DESCRIPTION
Update the contents and phrasing of the README, spec draft, and TAG security/privacy review to reflect the split of JSON modules into a separate Stage 2 proposal.

Also update a bit of wording in the 'Follow-up proposal "evaluator attributes"' section to better reflect the current thinking in module cache key behavior and limitations on using assertions for changes in module interpretation.


fixes https://github.com/tc39/proposal-import-assertions/issues/86