### PR TITLE
Allow an empty AssertClause

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37,6 +37,7 @@
       `export` `default` [lookahead &lt;! {`function`, `async` [no |LineTerminator| here] `function`, `class`}] AssignmentExpression[+In, ~Yield, ~Await] `;`
 
     AssertClause :
+      <ins>`assert` `{` `}`</ins>
       <ins>`assert` `{` AssertEntries `,`? `}`</ins>
 
     AssertEntries :
@@ -224,6 +225,11 @@
 
   <emu-clause id="sec-assert-clause-to-assertions" aoid="AssertClauseToAssertions">
     <h1>Runtime Semantics: AssertClauseToAssertions</h1>
+    <emu-grammar>AssertClause : `assert` `{` `}`</emu-grammar>
+    <emu-alg>
+      1. Return a new empty List.
+    </emu-alg>
+
     <emu-grammar>AssertClause : `assert` `{` AssertEntries `,`? `}`</emu-grammar>
     <emu-alg>
       1. Let _assertions_ be AssertClauseToAssertions of |AssertEntries|.


### PR DESCRIPTION
@waldemarhorwat pointed out during Stage 3 review that the current syntax does not permit an empty AssertClause.  Though an empty AssertClause would not be semantically different from leaving out the AssertClause altogether, it seems reasonable to allow an empty one for consistency's sake because other parts of `import`/`export` syntax permit empty lists.  For example it would be strange if the first `{ }` was permitted in the following statement (which is currently the case), but the second was not:
`import { } from "./foo.js" assert { }`.

Thus this PR edits the spec to allow an AssertClause that has no entries.

Closes #94.