### PR TITLE
Address Shu's stage 3 review feedback

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -97,7 +97,7 @@
             1. <ins>For each String _key_ of _keys_,</ins>
               1. <ins>Let _value_ be Get(_assertionsObj_, _key_).</ins>
               1. <ins>IfAbruptRejectPromise(_value_, _promiseCapability_).</ins>
-              1. <ins>Append { [[Key]]: _key_, [[Value]], _value_ } to _assertions_.</ins>
+              1. <ins>Append { [[Key]]: _key_, [[Value]]: _value_ } to _assertions_.</ins>
             1. <ins>Sort _assertions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among assertions by the order they occur in.</ens>
           1. <ins>Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Assertions]]: _assertions_ }.</ins>
           1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, <del>_specifierString_,</del> <ins>_moduleRequest_,</ins> _promiseCapability_).
@@ -224,7 +224,7 @@
   </emu-clause>
 
   <emu-clause id="sec-assert-clause-to-assertions" aoid="AssertClauseToAssertions">
-    <h1>Runtime Semantics: AssertClauseToAssertions</h1>
+    <h1>Static Semantics: AssertClauseToAssertions</h1>
     <emu-grammar>AssertClause : `assert` `{` `}`</emu-grammar>
     <emu-alg>
       1. Return a new empty List.
@@ -245,11 +245,14 @@
 
     <emu-grammar> AssertEntries : AssertionKey `:` StringLiteral `,` AssertEntries </emu-grammar>
     <emu-alg>
-      1. Let _entry_ be a Record { [[Key]]: AssertClauseToAssertions of |AssertionKey|, [[Value]]: StringValue of |StringLiteral| }.
+      1. Let _entry_ be a Record { [[Key]]: StringValue of |AssertionKey|, [[Value]]: StringValue of |StringLiteral| }.
       1. Let _rest_ be AssertClauseToAssertions of |AssertEntries|.
       1. Return a new List containing _entry_ followed by the entries of _rest_.
     </emu-alg>
+  </emu-clause>
 
+  <emu-clause id="sec-assertion-key-string-value">
+    <h1>Static Semantics: StringValue</h1>
     <emu-grammar> AssertionKey : IdentifierName </emu-grammar>
     <emu-alg>
       1. Return the StringValue of |IdentifierName|.
@@ -515,11 +518,11 @@
     <li>In the <a href="https://html.spec.whatwg.org/#fetch-the-descendants-of-a-module-script">fetch the descendents of a module script</a> algorithm, when iterating over [[RequestedModules]], the elements are ModuleRequest Records rather than just specifier strings; these Records is passed on to the internal module script graph fetching procedure (which sends it to "fetch a single module script". Other usage sites of [[RequestedModules]] ignore the assertion.</li>
     <li>"Fetch a single module script" would check the assertion in two places:
       <ul>
-        <li>If the module is found in the module map, then _type_ is checked against the module script's type field. If they differ, then an exception is thrown and module loading fails.</li>
+        <li>The module map is keyed with both the absolute URL and the module type, so an existing entry will be found only if its _type_ matches.</li>
         <li>When a new module is fetched, before writing it into the module map, the MIME type is checked to ensure that it matches _type_. (Note that the interpretation of the module is still driven by the MIME type, but once the MIME type is established, this is checked against the _type_.) If they differ, then an exception is thrown and module loading fails. The _type_ is written into the module script as the type.</li>
       </ul>
     </li>
   </ul>
 
-  <p>Note that the module map remains keyed by the absolute URL; the _type_ is not part of the module map key, and initially, no other import assertions are supported, so they are also not present.</p>
+  <p>The module map is keyed by the absolute URL and the _type_. Initially no other import assertions are supported, so they are not present.</p>
 </emu-annex>


### PR DESCRIPTION
Address @syg's review feedback:
- AssertClauseToAssertions should be Static Semantics.
- Pulled conversion of AssertionKey to string into separate __Static Semantics: StringValue__ section so that AssertClauseToAssertions  isn't so overloaded.
- Fix typo in 2.1.1 step 10.e.3: "[[Value]], -> [[Value]]:".
- Update __Sample Integration__ section to more closely reflect the current state of the HTML integration..