### PR TITLE
Create HostGetSupportedAssertions() and only give hosts supported assertions.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -90,11 +90,12 @@
           1. <ins>Let _arg_ be ? GetValue(_argRef_).</ins>
           1. <ins>If _arg_ is *undefined*, let _assertions_ be an empty List.</ins>
           1. <ins>Otherwise,</ins>
+            1. <ins>Let _supportedAssertions_ ! HostGetSupportedAssertions().</ins>
             1. <ins>Let _assertionsObj_ be ? Get(_arg_, *"assert"*).</ins>
             1. <ins>Let _assertions_ be a new empty List.</ins>
             1. <ins>Let _keys_ be EnumerableOwnPropertyNames(_assertionsObj_, ~key~).</ins>
             1. <ins>IfAbruptRejectPromise(_keys_, _promiseCapability_).</ins>
-            1. <ins>For each String _key_ of _keys_,</ins>
+            1. <ins>For each String _key_ of _keys_, if _key_ is an entry of _supportedAssertions_,</ins>
               1. <ins>Let _value_ be Get(_assertionsObj_, _key_).</ins>
               1. <ins>IfAbruptRejectPromise(_value_, _promiseCapability_).</ins>
               1. <ins>Append { [[Key]]: _key_, [[Value]]: _value_ } to _assertions_.</ins>
@@ -215,6 +216,28 @@
         </emu-alg>
       </emu-clause>
 
+  <emu-clause id="sec-hostgetsupportedassertions" aoid="HostGetSupportedAssertions">
+    <h1>Static Semantics: HostGetSupportedAssertions ()</h1>
+    <p>
+      HostGetSupportedAssertions is a host-defined abstract operation that allows host environments to specify which import assertions they support.
+      Only assertions with supported keys will be provided to the host.
+    </p>
+
+    <p>The implementation of HostGetSupportedAssertions must conform to the following requrements:</p>
+
+    <ul>
+      <li>It must return a List whose values are all StringValues, each indicating a supported assertion.</li>
+
+      <li>Each time this operation is called, it must return the same List instance with the same contents.</li>
+
+      <li>An implementation of HostGetSupportedAssertions must always complete normally (i.e., not return an abrupt completion).</li>
+    </ul>
+
+    <p>The default implementation of HostGetSupportedAssertions is to return an empty List.</p>
+
+    <emu-note type=editor>The purpose of requiring the host to specify its supported assertions, rather than passing all assertions to the host and letting it then choose which ones it wants to handle, is to ensure that unsupported assertions are handled in a consistent way across different hosts.</emu-note>
+  </emu-clause>
+
   <emu-clause id="sec-assert-clause-early-errors">
     <h1>Static Semantics: Early Errors</h1>
     <emu-grammar>AssertClause : `assert` `{` AssertEntries `,`? `}`</emu-grammar>
@@ -239,15 +262,23 @@
 
     <emu-grammar> AssertEntries : AssertionKey `:` StringLiteral </emu-grammar>
     <emu-alg>
-      1. Let _entry_ be a Record { [[Key]]: StringValue of |AssertionKey|, [[Value]]: StringValue of |StringLiteral| }.
-      1. Return a new List containing the single element, _entry_.
+      1. Let _supportedAssertions_ be !HostGetSupportedAssertions().
+      1. Let _key_ be StringValue of |AssertionKey|.
+      1. If _key_ is an entry of _supportedAssertions_,
+        1. Let _entry_ be a Record { [[Key]]: _key_, [[Value]]: StringValue of |StringLiteral| }.
+        1. Return a new List containing the single element, _entry_.
+      1. Otherwise, return a new empty List.
     </emu-alg>
 
     <emu-grammar> AssertEntries : AssertionKey `:` StringLiteral `,` AssertEntries </emu-grammar>
     <emu-alg>
-      1. Let _entry_ be a Record { [[Key]]: StringValue of |AssertionKey|, [[Value]]: StringValue of |StringLiteral| }.
-      1. Let _rest_ be AssertClauseToAssertions of |AssertEntries|.
-      1. Return a new List containing _entry_ followed by the entries of _rest_.
+      1. Let _supportedAssertions_ be !HostGetSupportedAssertions().
+      1. Let _key_ be StringValue of |AssertionKey|.
+      1. If _key_ is an entry of _supportedAssertions_,
+        1. Let _entry_ be a Record { [[Key]]: _key_, [[Value]]: StringValue of |StringLiteral| }.
+        1. Let _rest_ be AssertClauseToAssertions of |AssertEntries|.
+        1. Return a new List containing _entry_ followed by the entries of _rest_.
+      1. Otherwise, return AssertClauseToAssertions of |AssertEntries|.
     </emu-alg>
   </emu-clause>
 


### PR DESCRIPTION
Add a new host operation for hosts to specify the assertion keys that they support.  Only supported assertions are returned to the host.  This ensures that unsupported assertions will be handled in the same way (ignored) across all hosts.

Resolves #102.