### PR TITLE
Bugfix: Don't extract key's StringValue using AssertClauseToAssertion semantics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -239,7 +239,7 @@
 
     <emu-grammar> AssertEntries : AssertionKey `:` StringLiteral </emu-grammar>
     <emu-alg>
-      1. Let _entry_ be a Record { [[Key]]: AssertClauseToAssertions of |AssertionKey|, [[Value]]: StringValue of |StringLiteral| }.
+      1. Let _entry_ be a Record { [[Key]]: StringValue of |AssertionKey|, [[Value]]: StringValue of |StringLiteral| }.
       1. Return a new List containing the single element, _entry_.
     </emu-alg>
 


### PR DESCRIPTION
A small bugfix: we should use StringValue semantics instead of AssertClauseToAssertion semantics to get StringValue from assertion key.