### PR TITLE
Add missing ToString for assertion value in dynamic import() Runtime Semantics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -98,7 +98,9 @@
             1. <ins>For each String _key_ of _keys_, if _key_ is an entry of _supportedAssertions_,</ins>
               1. <ins>Let _value_ be Get(_assertionsObj_, _key_).</ins>
               1. <ins>IfAbruptRejectPromise(_value_, _promiseCapability_).</ins>
-              1. <ins>Append { [[Key]]: _key_, [[Value]]: _value_ } to _assertions_.</ins>
+              1. <ins>Let _valueString_ be ToString(_value_).</ins>
+              1. <ins>IfAbruptRejectPromise(_valueString_, _promiseCapability_).</ins>
+              1. <ins>Append { [[Key]]: _key_, [[Value]]: _valueString_ } to _assertions_.</ins>
             1. <ins>Sort _assertions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among assertions by the order they occur in.</ens>
           1. <ins>Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Assertions]]: _assertions_ }.</ins>
           1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, <del>_specifierString_,</del> <ins>_moduleRequest_,</ins> _promiseCapability_).

--- a/spec.html
+++ b/spec.html
@@ -95,12 +95,13 @@
             1. <ins>Let _assertions_ be a new empty List.</ins>
             1. <ins>Let _keys_ be EnumerableOwnPropertyNames(_assertionsObj_, ~key~).</ins>
             1. <ins>IfAbruptRejectPromise(_keys_, _promiseCapability_).</ins>
-            1. <ins>For each String _key_ of _keys_, if _key_ is an entry of _supportedAssertions_,</ins>
+            1. <ins>For each String _key_ of _keys_,</ins>
               1. <ins>Let _value_ be Get(_assertionsObj_, _key_).</ins>
               1. <ins>IfAbruptRejectPromise(_value_, _promiseCapability_).</ins>
-              1. <ins>Let _valueString_ be ToString(_value_).</ins>
-              1. <ins>IfAbruptRejectPromise(_valueString_, _promiseCapability_).</ins>
-              1. <ins>Append { [[Key]]: _key_, [[Value]]: _valueString_ } to _assertions_.</ins>
+              1. <ins>If Type(_value_) is not String, then</ins>
+                1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
+                1. <ins>Return _promiseCapability_.[[Promise]].</ins>
+              1. <ins>If _key_ is an entry of _supportedAssertions_, append { [[Key]]: _key_, [[Value]]: _value_ } to _assertions_.</ins>
             1. <ins>Sort _assertions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among assertions by the order they occur in.</ens>
           1. <ins>Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Assertions]]: _assertions_ }.</ins>
           1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, <del>_specifierString_,</del> <ins>_moduleRequest_,</ins> _promiseCapability_).


### PR DESCRIPTION
The Keys and Values in a ModuleRequest's [[Assertions]] list are supposed to be Strings. But, in the Runtime Semantics for the version of dynamic import() that takes an assertions argument, the `value` obtained from `assertionsObj` for a given assertion key inside the loop might not necessarily be a string.

This change adds the needed `ToString()` conversion before using the `value` in the assertions list.