### PR TITLE
Ensure Object type in dynamic import() Runtime Semantics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -88,11 +88,16 @@
           1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
           1. <ins>Let _argRef_ be the result of evaluating the second |AssignmentExpression|.</ins>
           1. <ins>Let _arg_ be ? GetValue(_argRef_).</ins>
-          1. <ins>If _arg_ is *undefined*, let _assertions_ be an empty List.</ins>
-          1. <ins>Otherwise,</ins>
-            1. <ins>Let _supportedAssertions_ ! HostGetSupportedImportAssertions().</ins>
+          1. <ins>Let _assertions_ be a new empty List.</ins>
+          1. <ins>If _arg_ is not *undefined*,</ins>
+            1. <ins>If Type(_arg_) is not Object, then</ins>
+              1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
+              1. <ins>Return _promiseCapability_.[[Promise]].</ins>
             1. <ins>Let _assertionsObj_ be ? Get(_arg_, *"assert"*).</ins>
-            1. <ins>Let _assertions_ be a new empty List.</ins>
+            1. <ins>If Type(_assertionsObj_) is not Object, then</ins>
+              1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
+              1. <ins>Return _promiseCapability_.[[Promise]].</ins>
+            1. <ins>Let _supportedAssertions_ ! HostGetSupportedImportAssertions().</ins>
             1. <ins>Let _keys_ be EnumerableOwnPropertyNames(_assertionsObj_, ~key~).</ins>
             1. <ins>IfAbruptRejectPromise(_keys_, _promiseCapability_).</ins>
             1. <ins>For each String _key_ of _keys_, if _key_ is an entry of _supportedAssertions_,</ins>

--- a/spec.html
+++ b/spec.html
@@ -94,17 +94,18 @@
               1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
               1. <ins>Return _promiseCapability_.[[Promise]].</ins>
             1. <ins>Let _assertionsObj_ be ? Get(_arg_, *"assert"*).</ins>
-            1. <ins>If Type(_assertionsObj_) is not Object, then</ins>
-              1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
-              1. <ins>Return _promiseCapability_.[[Promise]].</ins>
-            1. <ins>Let _supportedAssertions_ ! HostGetSupportedImportAssertions().</ins>
-            1. <ins>Let _keys_ be EnumerableOwnPropertyNames(_assertionsObj_, ~key~).</ins>
-            1. <ins>IfAbruptRejectPromise(_keys_, _promiseCapability_).</ins>
-            1. <ins>For each String _key_ of _keys_, if _key_ is an entry of _supportedAssertions_,</ins>
-              1. <ins>Let _value_ be Get(_assertionsObj_, _key_).</ins>
-              1. <ins>IfAbruptRejectPromise(_value_, _promiseCapability_).</ins>
-              1. <ins>Append { [[Key]]: _key_, [[Value]]: _value_ } to _assertions_.</ins>
-            1. <ins>Sort _assertions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among assertions by the order they occur in.</ens>
+            1. <ins>If _assertionsObj_ is not *undefined*,</ins>
+              1. <ins>If Type(_assertionsObj_) is not Object, then</ins>
+                1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
+                1. <ins>Return _promiseCapability_.[[Promise]].</ins>
+              1. <ins>Let _supportedAssertions_ ! HostGetSupportedImportAssertions().</ins>
+              1. <ins>Let _keys_ be EnumerableOwnPropertyNames(_assertionsObj_, ~key~).</ins>
+              1. <ins>IfAbruptRejectPromise(_keys_, _promiseCapability_).</ins>
+              1. <ins>For each String _key_ of _keys_, if _key_ is an entry of _supportedAssertions_,</ins>
+                1. <ins>Let _value_ be Get(_assertionsObj_, _key_).</ins>
+                1. <ins>IfAbruptRejectPromise(_value_, _promiseCapability_).</ins>
+                1. <ins>Append { [[Key]]: _key_, [[Value]]: _value_ } to _assertions_.</ins>
+              1. <ins>Sort _assertions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among assertions by the order they occur in.</ens>
           1. <ins>Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Assertions]]: _assertions_ }.</ins>
           1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, <del>_specifierString_,</del> <ins>_moduleRequest_,</ins> _promiseCapability_).
           1. Return _promiseCapability_.[[Promise]].


### PR DESCRIPTION
In the Runtime Semantics for the version of dynamic import() that takes an assertions argument, the second `argRef` and the `assertionsObj` are not guaranteed to be Objects.  e.g:
```js
import("./foo", 42);
import("./foo", { assert: 42 });
```
But, [Get()](https://tc39.es/ecma262/#sec-get-o-p) and [EnumerableOwnPropertyNames](https://tc39.es/ecma262/#sec-enumerableownpropertynames) both assert that the argument to them is an Object.

This change adds checks that these are of Type Object, and reject the promise with a TypeError if either is not.

`assertionsObj` is still allowed to be undefined.  This will be useful if we use the options bag for other things such as evaluator attributes, where a missing `assertionsObj` shouldn't result in failure:
```js
import('./foo", { with { transformA: "value" } });
```