### PR TITLE
Allow `type` in the cache key, and only pass that to the host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-dist
-
 # Installed npm modules
 package-lock.json
 node_modules

--- a/dist/ecmarkup.css
+++ b/dist/ecmarkup.css
@@ -1,0 +1,945 @@
+body {
+  display: flex;
+  font-size: 18px;
+  line-height: 1.5;
+  font-family: Cambria, Palatino Linotype, Palatino, Liberation Serif, serif;
+  padding: 0;
+  margin: 0;
+  color: #111;
+}
+
+#spec-container {
+  padding: 0 20px;
+  flex-grow: 1;
+  flex-basis: 66%;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+body.oldtoc {
+  margin: 0 auto;
+}
+
+a {
+    text-decoration: none;
+    color: #206ca7;
+}
+
+a:visited {
+  color: #206ca7;
+}
+
+a:hover {
+    text-decoration: underline;
+    color: #239dee;
+}
+
+
+code {
+    font-weight: bold;
+    font-family: Consolas, Monaco, monospace;
+    white-space: pre;
+}
+
+pre code {
+  font-weight: inherit;
+}
+
+pre code.hljs {
+  background-color: #fff;
+  margin: 0;
+  padding: 0;
+}
+
+ol.toc {
+    list-style: none;
+    padding-left: 0;
+}
+
+ol.toc ol.toc {
+    padding-left: 2ex;
+    list-style: none;
+}
+
+var {
+  color: #2aa198;
+  transition: background-color 0.25s ease;
+  cursor: pointer;
+}
+
+var.referenced {
+  background-color: #ffff33;
+}
+
+emu-const {
+  font-family: sans-serif;
+}
+
+emu-val {
+  font-weight: bold;
+}
+
+/* depth 1 */
+emu-alg ol,
+/* depth 4 */
+emu-alg ol ol ol ol,
+emu-alg ol.nested-thrice,
+emu-alg ol.nested-twice ol,
+emu-alg ol.nested-once ol ol {
+  list-style-type: decimal;
+}
+
+/* depth 2 */
+emu-alg ol ol,
+emu-alg ol.nested-once,
+/* depth 5 */
+emu-alg ol ol ol ol ol,
+emu-alg ol.nested-four-times,
+emu-alg ol.nested-thrice ol,
+emu-alg ol.nested-twice ol ol,
+emu-alg ol.nested-once ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+/* depth 3 */
+emu-alg ol ol ol,
+emu-alg ol.nested-twice,
+emu-alg ol.nested-once ol,
+/* depth 6 */
+emu-alg ol ol ol ol ol ol,
+emu-alg ol.nested-lots,
+emu-alg ol.nested-four-times ol,
+emu-alg ol.nested-thrice ol ol,
+emu-alg ol.nested-twice ol ol ol,
+emu-alg ol.nested-once ol ol ol ol,
+/* depth 7+ */
+emu-alg ol.nested-lots ol {
+  list-style-type: lower-roman;
+}
+
+emu-eqn {
+  display: block;
+  margin-left: 4em;
+}
+
+emu-eqn.inline {
+  display: inline;
+  margin: 0;
+}
+
+emu-eqn div:first-child {
+  margin-left: -2em;
+}
+
+emu-note {
+    margin: 1em 0;
+    color: #666;
+    border-left: 5px solid #ccc;
+    display: flex;
+    flex-direction: row;
+}
+
+emu-note > span.note {
+    flex-basis: 100px;
+    min-width: 100px;
+    flex-grow: 0;
+    flex-shrink: 1;
+    text-transform: uppercase;
+    padding-left: 5px;
+}
+
+emu-note[type=editor] {
+  border-left-color: #faa;
+}
+
+emu-note > div.note-contents {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+emu-note > div.note-contents > p:first-of-type {
+  margin-top: 0;
+}
+
+emu-note > div.note-contents > p:last-of-type {
+  margin-bottom: 0;
+}
+
+emu-table td code {
+  white-space: normal;
+} 
+
+emu-figure {
+  display: block;
+}
+
+emu-example {
+  display: block;
+  margin: 1em 3em;
+}
+
+emu-example figure figcaption {
+  margin-top: 0.5em;
+  text-align: left;
+}
+
+emu-figure figure,
+emu-example figure,
+emu-table figure {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+emu-production {
+    display: block;
+}
+
+emu-grammar[type="example"] emu-production,
+emu-grammar[type="definition"] emu-production {
+    margin-top: 1em;
+    margin-bottom: 1em;
+    margin-left: 5ex;
+}
+
+emu-grammar.inline, emu-production.inline,
+emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
+emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
+    display: inline;
+    padding-left: 1ex;
+    margin-left: 0;
+}
+
+emu-grammar[collapsed] emu-production, emu-production[collapsed] {
+    margin: 0;
+}
+
+emu-constraints {
+    font-size: .75em;
+    margin-right: 1ex;
+}
+
+emu-gann {
+    margin-right: 1ex;
+}
+
+emu-gann emu-t:last-child,
+emu-gann emu-gprose:last-child,
+emu-gann emu-nt:last-child {
+    margin-right: 0;
+}
+
+emu-geq {
+    margin-left: 1ex;
+    font-weight: bold;
+}
+
+emu-oneof {
+    font-weight: bold;
+    margin-left: 1ex;
+}
+
+emu-nt {
+    display: inline-block;
+    font-style: italic;
+    white-space: nowrap;
+    text-indent: 0;
+}
+
+emu-nt a, emu-nt a:visited {
+  color: #333;
+}
+
+emu-rhs emu-nt {
+    margin-right: 1ex;
+}
+
+emu-t {
+    display: inline-block;
+    font-family: monospace;
+    font-weight: bold;
+    white-space: nowrap;
+    text-indent: 0;
+}
+
+emu-production emu-t {
+    margin-right: 1ex;
+}
+
+emu-rhs {
+    display: block;
+    padding-left: 75px;
+    text-indent: -25px;
+}
+
+emu-mods {
+    font-size: .85em;
+    vertical-align: sub;
+    font-style: normal;
+    font-weight: normal;
+}
+
+emu-params, emu-opt {
+  margin-right: 1ex;
+  font-family: monospace;
+}
+
+emu-params, emu-constraints {
+  color: #2aa198;
+}
+
+emu-opt {
+  color: #b58900;
+}
+
+emu-gprose {
+    font-size: 0.9em;
+    font-family: Helvetica, Arial, sans-serif;
+}
+
+emu-production emu-gprose {
+    margin-right: 1ex;
+}
+
+h1.shortname {
+  color: #f60;
+  font-size: 1.5em;
+  margin: 0;
+}
+
+h1.version {
+  color: #f60;
+  font-size: 1.5em;
+  margin: 0;
+}
+
+h1.title {
+  margin-top: 0;
+  color: #f60;
+}
+
+h1.first {
+  margin-top: 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    position: relative;
+}
+
+h1 .secnum {
+  text-decoration: none;
+  margin-right: 5px;
+}
+
+h1 span.title {
+  order: 2;
+}
+
+
+h1 { font-size: 2.67em; margin-top: 2em; margin-bottom: 0; line-height: 1em;}
+h2 { font-size: 2em; }
+h3 { font-size: 1.56em; }
+h4 { font-size: 1.25em; }
+h5 { font-size: 1.11em; }
+h6 { font-size: 1em; }
+
+h1:hover span.utils {
+  display: block;
+}
+
+span.utils {
+  font-size: 18px;
+  line-height: 18px;
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  font-weight: normal;
+}
+
+span.utils:before {
+    content: "⤷";
+    display: inline-block;
+    padding: 0 5px;
+}
+
+span.utils > * {
+  display: inline-block;
+  margin-right: 20px;
+}
+
+h1 span.utils span.anchor a,
+h2 span.utils span.anchor a,
+h3 span.utils span.anchor a,
+h4 span.utils span.anchor a,
+h5 span.utils span.anchor a,
+h6 span.utils span.anchor a {
+  text-decoration: none;
+  font-variant: small-caps;
+}
+
+h1 span.utils span.anchor a:hover,
+h2 span.utils span.anchor a:hover,
+h3 span.utils span.anchor a:hover,
+h4 span.utils span.anchor a:hover,
+h5 span.utils span.anchor a:hover,
+h6 span.utils span.anchor a:hover {
+  color: #333;
+}
+
+emu-intro h1, emu-clause h1, emu-annex h1 { font-size: 2em; }
+emu-intro h2, emu-clause h2, emu-annex h2 { font-size: 1.56em; }
+emu-intro h3, emu-clause h3, emu-annex h3 { font-size: 1.25em; }
+emu-intro h4, emu-clause h4, emu-annex h4 { font-size: 1.11em; }
+emu-intro h5, emu-clause h5, emu-annex h5 { font-size: 1em; }
+emu-intro h6, emu-clause h6, emu-annex h6 { font-size: 0.9em; }
+emu-intro emu-intro h1, emu-clause emu-clause h1, emu-annex emu-annex h1 { font-size: 1.56em; }
+emu-intro emu-intro h2, emu-clause emu-clause h2, emu-annex emu-annex h2 { font-size: 1.25em; }
+emu-intro emu-intro h3, emu-clause emu-clause h3, emu-annex emu-annex h3 { font-size: 1.11em; }
+emu-intro emu-intro h4, emu-clause emu-clause h4, emu-annex emu-annex h4 { font-size: 1em; }
+emu-intro emu-intro h5, emu-clause emu-clause h5, emu-annex emu-annex h5 { font-size: 0.9em; }
+emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex h1 { font-size: 1.25em; }
+emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex h2 { font-size: 1.11em; }
+emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex h3 { font-size: 1em; }
+emu-intro emu-intro emu-intro h4, emu-clause emu-clause emu-clause h4, emu-annex emu-annex emu-annex h4 { font-size: 0.9em; }
+emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1.11em; }
+emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex h2 { font-size: 1em; }
+emu-intro emu-intro emu-intro emu-intro h3, emu-clause emu-clause emu-clause emu-clause h3, emu-annex emu-annex emu-annex emu-annex h3 { font-size: 0.9em; }
+emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 1em; }
+emu-intro emu-intro emu-intro emu-intro emu-intro h2, emu-clause emu-clause emu-clause emu-clause emu-clause h2, emu-annex emu-annex emu-annex emu-annex emu-annex h2 { font-size: 0.9em; }
+emu-intro emu-intro emu-intro emu-intro emu-intro emu-intro h1, emu-clause emu-clause emu-clause emu-clause emu-clause emu-clause h1, emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex h1 { font-size: 0.9em }
+
+emu-clause, emu-intro, emu-annex {
+    display: block;
+}
+
+/* Figures and tables */
+figure { display: block; margin: 1em 0 3em 0; }
+figure object { display: block; margin: 0 auto; }
+figure table.real-table { margin: 0 auto; }
+figure figcaption {
+    display: block;
+    color: #555555;
+    font-weight: bold;
+    text-align: center;
+}
+
+emu-table table {
+  margin: 0 auto;
+}
+
+emu-table table, table.real-table {
+    border-collapse: collapse;
+}
+
+emu-table td, emu-table th, table.real-table td, table.real-table th {
+    border: 1px solid black;
+    padding: 0.4em;
+    vertical-align: baseline;
+}
+emu-table th, emu-table thead td, table.real-table th {
+    background-color: #eeeeee;
+}
+
+/* Note: the left content edges of table.lightweight-table >tbody >tr >td
+   and div.display line up. */
+table.lightweight-table {
+    border-collapse: collapse;
+    margin: 0 0 0 1.5em;
+}
+table.lightweight-table td, table.lightweight-table th {
+    border: none;
+    padding: 0 0.5em;
+    vertical-align: baseline;
+}
+
+/* diff styles */
+ins {
+    background-color: #e0f8e0;
+    text-decoration: none;
+    border-bottom: 1px solid #396;
+}
+
+del {
+    background-color: #fee;
+}
+
+ins.block, del.block,
+emu-production > ins, emu-production > del,
+emu-grammar > ins, emu-grammar > del {
+  display: block;
+}
+emu-rhs > ins, emu-rhs > del { 
+  display: inline;
+}
+
+tr.ins > td > ins {
+  border-bottom: none;
+}
+
+tr.ins > td {
+  background-color: #e0f8e0;
+}
+
+tr.del > td {
+  background-color: #fee;
+}
+
+/* Menu Styles */
+#menu-toggle {
+  font-size: 2em;
+
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 1.5em;
+  height: 1.5em;
+  z-index: 3;
+  visibility: hidden;
+  color: #1567a2;
+  background-color: #fff;
+
+  line-height: 1.5em;
+  text-align: center;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;;
+
+  cursor: pointer;
+}
+
+#menu {
+  display: flex;
+  flex-direction: column;
+  width: 33%; height: 100vh;
+  max-width: 500px;
+  box-sizing: border-box;
+  background-color: #ddd;
+  overflow: hidden;
+  transition: opacity 0.1s linear;
+  padding: 0 5px;
+  position: fixed;
+  left: 0; top: 0;
+  border-right: 2px solid #bbb;
+
+  z-index: 2;
+}
+
+#menu-spacer {
+  flex-basis: 33%;
+  max-width: 500px;
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+#menu a {
+  color: #1567a2;
+}
+
+#menu.active {
+  display: flex;
+  opacity: 1;
+  z-index: 2;
+}
+
+#menu-pins {
+  flex-grow: 1;
+  display: none;
+}
+
+#menu-pins.active {
+  display: block;
+}
+
+#menu-pins-list {
+  margin: 0;
+  padding: 0;
+  counter-reset: pins-counter;
+}
+
+#menu-pins-list > li:before {
+  content: counter(pins-counter);
+  counter-increment: pins-counter;
+  display: inline-block;
+  width: 25px;
+  text-align: center;
+  border: 1px solid #bbb;
+  padding: 2px;
+  margin: 4px;
+  box-sizing: border-box;
+  line-height: 1em;
+  background-color: #ccc;
+  border-radius: 4px;
+}
+#menu-toc > ol {
+  padding: 0;
+  flex-grow: 1;
+}
+
+#menu-toc > ol li {
+  padding: 0;
+}
+
+#menu-toc > ol , #menu-toc > ol ol {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+#menu-toc > ol ol {
+  padding-left: 0.75em;
+}
+
+#menu-toc li {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+#menu-toc .item-toggle {
+  display: inline-block;
+  transform: rotate(-45deg) translate(-5px, -5px);
+  transition: transform 0.1s ease;
+  text-align: center;
+  width: 20px;
+
+  color: #aab;
+
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;;
+
+  cursor: pointer;
+}
+
+#menu-toc .item-toggle-none {
+  display: inline-block;
+  width: 20px;
+}
+
+#menu-toc li.active > .item-toggle {
+  transform: rotate(45deg) translate(-5px, -5px);
+}
+
+#menu-toc li > ol {
+  display: none;
+}
+
+#menu-toc li.active > ol {
+  display: block;
+}
+
+#menu-toc li.revealed > a {
+  background-color: #bbb;
+  font-weight: bold;
+  /*
+  background-color: #222;
+  color: #c6d8e4;
+  */
+}
+
+#menu-toc li.revealed-leaf> a {
+  color: #206ca7;
+  /*
+  background-color: #222;
+  color: #c6d8e4;
+  */
+}
+
+#menu-toc li.revealed > .item-toggle {
+  transform: rotate(45deg) translate(-5px, -5px);
+}
+
+#menu-toc li.revealed > ol {
+  display: block;
+}
+
+#menu-toc li > a {
+  padding: 2px 5px;
+}
+
+#menu > * {
+  margin-bottom: 5px;
+}
+
+.menu-pane-header {
+  padding: 0 5px;
+  text-transform: uppercase;
+  background-color: #aaa;
+  color: #335;
+  font-weight: bold;
+  letter-spacing: 2px;
+  flex-grow: 0;
+  flex-shrink: 0;
+  font-size: 0.8em;
+}
+
+#menu-toc {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  overflow: hidden;
+  flex-grow: 1;
+}
+
+#menu-toc ol.toc {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+#menu-search {
+  position: relative;
+  flex-grow: 0;
+  flex-shrink: 0;
+  width: 100%;
+  
+  display: flex;
+  flex-direction: column;
+  
+  max-height: 300px;
+}
+
+#menu-trace-list {
+  display: none;
+}
+
+#menu-search-box {
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  margin: 5px 0 0 0;
+  font-size: 1em;
+  padding: 2px;
+  background-color: #bbb;
+  border: 1px solid #999;
+}
+
+#menu-search-results {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+li.menu-search-result-clause:before {
+    content: 'clause';
+    width: 40px;
+    display: inline-block;
+    text-align: right;
+    padding-right: 1ex;
+    color: #666;
+    font-size: 75%;
+}
+li.menu-search-result-op:before {
+    content: 'op';
+    width: 40px;
+    display: inline-block;
+    text-align: right;
+    padding-right: 1ex;
+    color: #666;
+    font-size: 75%;
+}
+
+li.menu-search-result-prod:before {
+    content: 'prod';
+    width: 40px;
+    display: inline-block;
+    text-align: right;
+    padding-right: 1ex;
+    color: #666;
+    font-size: 75%
+}
+
+
+li.menu-search-result-term:before {
+    content: 'term';
+    width: 40px;
+    display: inline-block;
+    text-align: right;
+    padding-right: 1ex;
+    color: #666;
+    font-size: 75%
+}
+
+#menu-search-results ul {
+  padding: 0 5px;
+  margin: 0;
+}
+
+#menu-search-results li {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+
+#menu-trace-list {
+  counter-reset: item;
+  margin: 0 0 0 20px;
+  padding: 0;
+}
+#menu-trace-list li {
+  display: block;
+  white-space: nowrap;
+}
+
+#menu-trace-list li .secnum:after {
+  content: " ";
+}
+#menu-trace-list li:before {
+    content: counter(item) " ";
+    background-color: #222;
+    counter-increment: item;
+    color: #999;
+    width: 20px;
+    height: 20px;
+    line-height: 20px;
+    display: inline-block;
+    text-align: center;
+    margin: 2px 4px 2px 0;
+}
+
+@media (max-width: 1000px) {
+  body {
+    margin: 0;
+    display: block;
+  }
+
+  #menu {
+    display: none;
+    padding-top: 3em;
+    width: 450px;
+  }
+
+  #menu.active {
+    position: fixed;
+    height: 100%;
+    left: 0;
+    top: 0;
+    right: 300px;
+  }
+
+  #menu-toggle {
+    visibility: visible;
+  }
+
+  #spec-container {
+    padding: 0 5px;
+  }
+
+  #references-pane-spacer {
+    display: none;
+  }
+}
+
+@media only screen and (max-width: 800px) {
+  #menu {
+    width: 100%;
+  }
+
+  h1 .secnum:empty {
+    margin: 0; padding: 0;
+  }
+}
+
+
+/* Toolbox */
+.toolbox {
+	position: absolute;
+	background: #ddd;
+	border: 1px solid #aaa;
+  display: none;
+  color: #eee;
+  padding: 5px;
+  border-radius: 3px;
+}
+
+.toolbox.active {
+  display: inline-block;
+}
+
+.toolbox a {
+  text-decoration: none;
+  padding: 0 5px;
+}
+
+.toolbox a:hover {
+  text-decoration: underline;
+}
+
+.toolbox:after, .toolbox:before {
+	top: 100%;
+	left: 15px;
+	border: solid transparent;
+	content: " ";
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none;
+}
+
+.toolbox:after {
+	border-color: rgba(0, 0, 0, 0);
+	border-top-color: #ddd;
+	border-width: 10px;
+	margin-left: -10px;
+}
+.toolbox:before {
+	border-color: rgba(204, 204, 204, 0);
+	border-top-color: #aaa;
+	border-width: 12px;
+	margin-left: -12px;
+}
+
+#references-pane-container {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 250px;
+  display: none;
+  background-color: #ddd;
+  z-index: 1;
+}
+
+#references-pane-table-container {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+#references-pane-spacer {
+  flex-basis: 33%;
+  max-width: 500px;
+}
+
+#references-pane {
+  flex-grow: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+#references-pane-container.active {
+  display: flex;
+}
+
+#references-pane-close:after {
+  content: '✖';
+  float: right;
+  cursor: pointer;
+}
+
+#references-pane table tr td:first-child {
+  text-align: right;
+  padding-right: 5px;
+}
+
+@media print {
+  #menu-toggle {
+    display: none; 
+  }
+}

--- a/dist/ecmarkup.js
+++ b/dist/ecmarkup.js
@@ -1,0 +1,897 @@
+"use strict";
+
+function Search(menu) {
+  this.menu = menu;
+  this.$search = document.getElementById('menu-search');
+  this.$searchBox = document.getElementById('menu-search-box');
+  this.$searchResults = document.getElementById('menu-search-results');
+
+  this.loadBiblio();
+
+  document.addEventListener('keydown', this.documentKeydown.bind(this));
+
+  this.$searchBox.addEventListener('keydown', debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }));
+  this.$searchBox.addEventListener('keyup', debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }));
+
+  // Perform an initial search if the box is not empty.
+  if (this.$searchBox.value) {
+    this.search(this.$searchBox.value);
+  }
+}
+
+Search.prototype.loadBiblio = function () {
+  var $biblio = document.getElementById('menu-search-biblio');
+  if (!$biblio) {
+    this.biblio = [];
+  } else {
+    this.biblio = JSON.parse($biblio.textContent);
+    this.biblio.clauses = this.biblio.filter(function (e) { return e.type === 'clause' });
+    this.biblio.byId = this.biblio.reduce(function (map, entry) {
+      map[entry.id] = entry;
+      return map;
+    }, {});
+  }
+}
+
+Search.prototype.documentKeydown = function (e) {
+  if (e.keyCode === 191) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.triggerSearch();
+  }
+}
+
+Search.prototype.searchBoxKeydown = function (e) {
+  e.stopPropagation();
+  e.preventDefault();
+  if (e.keyCode === 191 && e.target.value.length === 0) {
+    e.preventDefault();
+  } else if (e.keyCode === 13) {
+    e.preventDefault();
+    this.selectResult();
+  }
+}
+
+Search.prototype.searchBoxKeyup = function (e) {
+  if (e.keyCode === 13 || e.keyCode === 9) {
+    return;
+  }
+
+  this.search(e.target.value);
+}
+
+
+Search.prototype.triggerSearch = function (e) {
+  if (this.menu.isVisible()) {
+    this._closeAfterSearch = false;
+  } else {
+    this._closeAfterSearch = true;
+    this.menu.show();
+  }
+
+  this.$searchBox.focus();
+  this.$searchBox.select();
+}
+// bit 12 - Set if the result starts with searchString
+// bits 8-11: 8 - number of chunks multiplied by 2 if cases match, otherwise 1.
+// bits 1-7: 127 - length of the entry
+// General scheme: prefer case sensitive matches with fewer chunks, and otherwise
+// prefer shorter matches.
+function relevance(result, searchString) {
+  var relevance = 0;
+
+  relevance = Math.max(0, 8 - result.match.chunks) << 7;
+
+  if (result.match.caseMatch) {
+    relevance *= 2;
+  }
+
+  if (result.match.prefix) {
+    relevance += 2048
+  }
+
+  relevance += Math.max(0, 255 - result.entry.key.length);
+
+  return relevance;
+}
+
+Search.prototype.search = function (searchString) {
+  if (searchString === '') {
+    this.displayResults([]);
+    this.hideSearch();
+    return;
+  } else {
+    this.showSearch();
+  }
+
+  if (searchString.length === 1) {
+    this.displayResults([]);
+    return;
+  }
+
+  var results;
+
+  if (/^[\d\.]*$/.test(searchString)) {
+    results = this.biblio.clauses.filter(function (clause) {
+      return clause.number.substring(0, searchString.length) === searchString;
+    }).map(function (clause) {
+      return { entry: clause };
+    });
+  } else {
+    results = [];
+
+    for (var i = 0; i < this.biblio.length; i++) {
+      var entry = this.biblio[i];
+      if (!entry.key) {
+        // biblio entries without a key aren't searchable
+        continue;
+      }
+
+      var match = fuzzysearch(searchString, entry.key);
+      if (match) {
+        results.push({ entry: entry, match: match });
+      }
+    }
+
+    results.forEach(function (result) {
+      result.relevance = relevance(result, searchString);
+    });
+
+    results = results.sort(function (a, b) { return b.relevance - a.relevance });
+
+  }
+
+  if (results.length > 50) {
+    results = results.slice(0, 50);
+  }
+
+  this.displayResults(results);
+}
+Search.prototype.hideSearch = function () {
+  this.$search.classList.remove('active');
+}
+
+Search.prototype.showSearch = function () {
+  this.$search.classList.add('active');
+}
+
+Search.prototype.selectResult = function () {
+  var $first = this.$searchResults.querySelector('li:first-child a');
+
+  if ($first) {
+    document.location = $first.getAttribute('href');
+  }
+
+  this.$searchBox.value = '';
+  this.$searchBox.blur();
+  this.displayResults([]);
+  this.hideSearch();
+
+  if (this._closeAfterSearch) {
+    this.menu.hide();
+  }
+}
+
+Search.prototype.displayResults = function (results) {
+  if (results.length > 0) {
+    this.$searchResults.classList.remove('no-results');
+
+    var html = '<ul>';
+
+    results.forEach(function (result) {
+      var entry = result.entry;
+      var id = entry.id;
+      var cssClass = '';
+      var text = '';
+
+      if (entry.type === 'clause') {
+        var number = entry.number ? entry.number + ' ' : '';
+        text = number + entry.key;
+        cssClass = 'clause';
+        id = entry.id;
+      } else if (entry.type === 'production') {
+        text = entry.key;
+        cssClass = 'prod';
+        id = entry.id;
+      } else if (entry.type === 'op') {
+        text = entry.key;
+        cssClass = 'op';
+        id = entry.id || entry.refId;
+      } else if (entry.type === 'term') {
+        text = entry.key;
+        cssClass = 'term';
+        id = entry.id || entry.refId;
+      }
+
+      if (text) {
+        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>';
+      }
+    });
+
+    html += '</ul>'
+
+    this.$searchResults.innerHTML = html;
+  } else {
+    this.$searchResults.innerHTML = '';
+    this.$searchResults.classList.add('no-results');
+  }
+}
+
+
+function Menu() {
+  this.$toggle = document.getElementById('menu-toggle');
+  this.$menu = document.getElementById('menu');
+  this.$toc = document.querySelector('menu-toc > ol');
+  this.$pins = document.querySelector('#menu-pins');
+  this.$pinList = document.getElementById('menu-pins-list');
+  this.$toc = document.querySelector('#menu-toc > ol');
+  this.$specContainer = document.getElementById('spec-container');
+  this.search = new Search(this);
+
+  this._pinnedIds = {}; 
+  this.loadPinEntries();
+
+  // toggle menu
+  this.$toggle.addEventListener('click', this.toggle.bind(this));
+
+  // keydown events for pinned clauses
+  document.addEventListener('keydown', this.documentKeydown.bind(this));
+
+  // toc expansion
+  var tocItems = this.$menu.querySelectorAll('#menu-toc li');
+  for (var i = 0; i < tocItems.length; i++) {
+    var $item = tocItems[i];
+    $item.addEventListener('click', function($item, event) {
+      $item.classList.toggle('active');
+      event.stopPropagation();
+    }.bind(null, $item));
+  }
+
+  // close toc on toc item selection
+  var tocLinks = this.$menu.querySelectorAll('#menu-toc li > a');
+  for (var i = 0; i < tocLinks.length; i++) {
+    var $link = tocLinks[i];
+    $link.addEventListener('click', function(event) {
+      this.toggle();
+      event.stopPropagation();
+    }.bind(this));
+  }
+
+  // update active clause on scroll
+  window.addEventListener('scroll', debounce(this.updateActiveClause.bind(this)));
+  this.updateActiveClause();
+
+  // prevent menu scrolling from scrolling the body
+  this.$toc.addEventListener('wheel', function (e) {
+    var target = e.currentTarget;
+    var offTop = e.deltaY < 0 && target.scrollTop === 0;
+    if (offTop) {
+      e.preventDefault();
+    }
+    var offBottom = e.deltaY > 0
+                    && target.offsetHeight + target.scrollTop >= target.scrollHeight;
+
+    if (offBottom) {
+      e.preventDefault();
+    }
+  });
+}
+
+Menu.prototype.documentKeydown = function (e) {
+  e.stopPropagation();
+  if (e.keyCode === 80) {
+    this.togglePinEntry();
+  } else if (e.keyCode > 48 && e.keyCode < 58) {
+    this.selectPin(e.keyCode - 49);
+  }
+}
+
+Menu.prototype.updateActiveClause = function () {
+  this.setActiveClause(findActiveClause(this.$specContainer))
+}
+
+Menu.prototype.setActiveClause = function (clause) {
+  this.$activeClause = clause;
+  this.revealInToc(this.$activeClause);
+}
+
+Menu.prototype.revealInToc = function (path) {
+  var current = this.$toc.querySelectorAll('li.revealed');
+  for (var i = 0; i < current.length; i++) {
+    current[i].classList.remove('revealed');
+    current[i].classList.remove('revealed-leaf');
+  }
+
+  var current = this.$toc;
+  var index = 0;
+  while (index < path.length) {
+    var children = current.children;
+    for (var i = 0; i < children.length; i++) {
+      if ('#' + path[index].id === children[i].children[1].getAttribute('href') ) {
+        children[i].classList.add('revealed');
+        if (index === path.length - 1) {
+          children[i].classList.add('revealed-leaf');
+          var rect = children[i].getBoundingClientRect();
+          // this.$toc.getBoundingClientRect().top;
+          var tocRect = this.$toc.getBoundingClientRect();
+          if (rect.top + 10 > tocRect.bottom) {
+            this.$toc.scrollTop = this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
+          } else if (rect.top < tocRect.top) {
+            this.$toc.scrollTop = this.$toc.scrollTop - (tocRect.top - rect.top);
+          }
+        }
+        current = children[i].querySelector('ol');
+        index++;
+        break;
+      }
+    }
+
+  }
+}
+
+function findActiveClause(root, path) {
+  var clauses = new ClauseWalker(root);
+  var $clause;
+  var path = path || [];
+
+  while ($clause = clauses.nextNode()) {
+    var rect = $clause.getBoundingClientRect();
+    var $header = $clause.querySelector("h1");
+    var marginTop = parseInt(getComputedStyle($header)["margin-top"]);
+
+    if ((rect.top - marginTop) <= 0 && rect.bottom > 0) {
+      return findActiveClause($clause, path.concat($clause)) || path;
+    }
+  }
+
+  return path;
+}
+
+function ClauseWalker(root) {
+  var previous;
+  var treeWalker = document.createTreeWalker(
+    root,
+    NodeFilter.SHOW_ELEMENT,
+    {
+      acceptNode: function (node) {
+        if (previous === node.parentNode) {
+          return NodeFilter.FILTER_REJECT;
+        } else {
+          previous = node;
+        }
+        if (node.nodeName === 'EMU-CLAUSE' || node.nodeName === 'EMU-INTRO' || node.nodeName === 'EMU-ANNEX') {
+          return NodeFilter.FILTER_ACCEPT;
+        } else {
+          return NodeFilter.FILTER_SKIP;
+        }
+      }
+    },
+    false
+    );
+
+  return treeWalker;
+}
+
+Menu.prototype.toggle = function () {
+  this.$menu.classList.toggle('active');
+}
+
+Menu.prototype.show = function () {
+  this.$menu.classList.add('active');
+}
+
+Menu.prototype.hide = function () {
+  this.$menu.classList.remove('active');
+}
+
+Menu.prototype.isVisible = function() {
+  return this.$menu.classList.contains('active');
+}
+
+Menu.prototype.showPins = function () {
+  this.$pins.classList.add('active');
+}
+
+Menu.prototype.hidePins = function () {
+  this.$pins.classList.remove('active');
+}
+
+Menu.prototype.addPinEntry = function (id) {
+  var entry = this.search.biblio.byId[id];
+  if (!entry) {
+    // id was deleted after pin (or something) so remove it
+    delete this._pinnedIds[id];
+    this.persistPinEntries();
+    return;
+  }
+
+  if (entry.type === 'clause') {
+    var prefix;
+    if (entry.number) {
+      prefix = entry.number + ' ';
+    } else {
+      prefix = '';
+    }
+    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + prefix + entry.titleHTML + '</a></li>';
+  } else {
+    this.$pinList.innerHTML += '<li><a href="#' + entry.id + '">' + entry.key + '</a></li>';
+  }
+
+  if (Object.keys(this._pinnedIds).length === 0) {
+    this.showPins();
+  }
+  this._pinnedIds[id] = true;
+  this.persistPinEntries();
+}
+
+Menu.prototype.removePinEntry = function (id) {
+  var item = this.$pinList.querySelector('a[href="#' + id + '"]').parentNode;
+  this.$pinList.removeChild(item);
+  delete this._pinnedIds[id];
+  if (Object.keys(this._pinnedIds).length === 0) {
+    this.hidePins();
+  }
+
+  this.persistPinEntries();
+}
+
+Menu.prototype.persistPinEntries = function () {
+  try {
+    if (!window.localStorage) return;
+  } catch (e) {
+    return;
+  }
+
+  localStorage.pinEntries = JSON.stringify(Object.keys(this._pinnedIds));
+}
+
+Menu.prototype.loadPinEntries = function () {
+  try {
+    if (!window.localStorage) return;
+  } catch (e) {
+    return;
+  }
+
+  var pinsString = window.localStorage.pinEntries;
+  if (!pinsString) return;
+  var pins = JSON.parse(pinsString);
+  for(var i = 0; i < pins.length; i++) {
+    this.addPinEntry(pins[i]);
+  }
+}
+
+Menu.prototype.togglePinEntry = function (id) {
+  if (!id) {
+    id = this.$activeClause[this.$activeClause.length - 1].id;
+  }
+
+  if (this._pinnedIds[id]) {
+    this.removePinEntry(id);
+  } else {
+    this.addPinEntry(id);
+  }
+}
+
+Menu.prototype.selectPin = function (num) {
+  document.location = this.$pinList.children[num].children[0].href;
+}
+
+var menu;
+function init() {
+  menu = new Menu();
+  var $container = document.getElementById('spec-container');
+  $container.addEventListener('mouseover', debounce(function (e) {
+    Toolbox.activateIfMouseOver(e);
+  }));
+  document.addEventListener('keydown', debounce(function (e) {
+    if (e.code === "Escape" && Toolbox.active) {
+      Toolbox.deactivate();
+    }
+  }));
+}
+
+document.addEventListener('DOMContentLoaded', init);
+
+function debounce(fn, opts) {
+  opts = opts || {};
+  var timeout;
+  return function(e) {
+    if (opts.stopPropagation) {
+      e.stopPropagation();
+    }
+    var args = arguments;
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(function() {
+      timeout = null;
+      fn.apply(this, args);
+    }.bind(this), 150);
+  }
+}
+
+var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
+function findLocalReferences ($elem) {
+  var name = $elem.innerHTML;
+  var references = [];
+
+  var parentClause = $elem.parentNode;
+  while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
+    parentClause = parentClause.parentNode;
+  }
+
+  if(!parentClause) return;
+
+  var vars = parentClause.querySelectorAll('var');
+
+  for (var i = 0; i < vars.length; i++) {
+    var $var = vars[i];
+
+    if ($var.innerHTML === name) {
+      references.push($var);
+    }
+  }
+
+  return references;
+}
+
+function toggleFindLocalReferences($elem) {
+  var references = findLocalReferences($elem);
+  if ($elem.classList.contains('referenced')) {
+    references.forEach(function ($reference) {
+      $reference.classList.remove('referenced');
+    });
+  } else {
+    references.forEach(function ($reference) {
+      $reference.classList.add('referenced');
+    });
+  }
+}
+
+function installFindLocalReferences () {
+  document.addEventListener('click', function (e) {
+    if (e.target.nodeName === 'VAR') {
+      toggleFindLocalReferences(e.target);
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', installFindLocalReferences);
+
+
+
+
+// The following license applies to the fuzzysearch function
+// The MIT License (MIT)
+// Copyright © 2015 Nicolas Bevacqua
+// Copyright © 2016 Brian Terlson
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+function fuzzysearch (searchString, haystack, caseInsensitive) {
+  var tlen = haystack.length;
+  var qlen = searchString.length;
+  var chunks = 1;
+  var finding = false;
+
+  if (qlen > tlen) {
+    return false;
+  }
+
+  if (qlen === tlen) {
+    if (searchString === haystack) {
+      return { caseMatch: true, chunks: 1, prefix: true };
+    } else if (searchString.toLowerCase() === haystack.toLowerCase()) {
+      return { caseMatch: false, chunks: 1, prefix: true };
+    } else {
+      return false;
+    }
+  }
+
+  outer: for (var i = 0, j = 0; i < qlen; i++) {
+    var nch = searchString[i];
+    while (j < tlen) {
+      var targetChar = haystack[j++];
+      if (targetChar === nch) {
+        finding = true;
+        continue outer;
+      }
+      if (finding) {
+        chunks++;
+        finding = false;
+      }
+    }
+
+    if (caseInsensitive) { return false; }
+
+    return fuzzysearch(searchString.toLowerCase(), haystack.toLowerCase(), true);
+  }
+
+  return { caseMatch: !caseInsensitive, chunks: chunks, prefix: j <= qlen };
+}
+
+var Toolbox = {
+  init: function () {
+    this.$container = document.createElement('div');
+    this.$container.classList.add('toolbox');
+    this.$permalink = document.createElement('a');
+    this.$permalink.textContent = 'Permalink';
+    this.$pinLink = document.createElement('a');
+    this.$pinLink.textContent = 'Pin';
+    this.$pinLink.setAttribute('href', '#');
+    this.$pinLink.addEventListener('click', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      menu.togglePinEntry(this.entry.id);
+    }.bind(this));
+
+    this.$refsLink = document.createElement('a');
+    this.$refsLink.setAttribute('href', '#');
+    this.$refsLink.addEventListener('click', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      referencePane.showReferencesFor(this.entry);
+    }.bind(this));
+    this.$container.appendChild(this.$permalink);
+    this.$container.appendChild(this.$pinLink);
+    this.$container.appendChild(this.$refsLink);
+    document.body.appendChild(this.$container);
+  },
+
+  activate: function (el, entry, target) {
+    if (el === this._activeEl) return;
+    this.active = true;
+    this.entry = entry;
+    this.$container.classList.add('active');
+    this.top = el.offsetTop - this.$container.offsetHeight - 10;
+    this.left = el.offsetLeft;
+    this.$container.setAttribute('style', 'left: ' + this.left + 'px; top: ' + this.top + 'px');
+    this.updatePermalink();
+    this.updateReferences();
+    this._activeEl = el;
+    if (this.top < document.body.scrollTop && el === target) {
+      // don't scroll unless it's a small thing (< 200px)
+      this.$container.scrollIntoView();
+    }
+  },
+
+  updatePermalink: function () {
+    this.$permalink.setAttribute('href', '#' + this.entry.id);
+  },
+
+  updateReferences: function () {
+    this.$refsLink.textContent = 'References (' + this.entry.referencingIds.length + ')';
+  },
+
+  activateIfMouseOver: function (e) {
+    var ref = this.findReferenceUnder(e.target);
+    if (ref && (!this.active || e.pageY > this._activeEl.offsetTop)) {
+      var entry = menu.search.biblio.byId[ref.id];
+      this.activate(ref.element, entry, e.target);
+    } else if (this.active && ((e.pageY < this.top) || e.pageY > (this._activeEl.offsetTop + this._activeEl.offsetHeight))) {
+      this.deactivate();
+    }
+  },
+
+  findReferenceUnder: function (el) {
+    while (el) {
+      var parent = el.parentNode;
+      if (el.nodeName === 'H1' && parent.nodeName.match(/EMU-CLAUSE|EMU-ANNEX|EMU-INTRO/) && parent.id) {
+        return { element: el, id: parent.id };
+      } else if (el.nodeName.match(/EMU-(?!CLAUSE|XREF|ANNEX|INTRO)|DFN/) &&
+                el.id && el.id[0] !== '_') {
+        if (el.nodeName === 'EMU-FIGURE' || el.nodeName === 'EMU-TABLE' || el.nodeName === 'EMU-EXAMPLE') {
+          // return the figcaption element
+          return { element: el.children[0].children[0], id: el.id };
+        } else if (el.nodeName === 'EMU-PRODUCTION') {
+          // return the LHS non-terminal element
+          return { element: el.children[0], id: el.id };
+        } else {
+          return { element: el, id: el.id };
+        }
+      }
+      el = parent;
+    }
+  },
+
+  deactivate: function () {
+    this.$container.classList.remove('active');
+    this._activeEl = null;
+    this.activeElBounds = null;
+    this.active = false;
+  }
+}
+
+var referencePane = {
+  init: function() {
+    this.$container = document.createElement('div');
+    this.$container.setAttribute('id', 'references-pane-container');
+
+    var $spacer = document.createElement('div');
+    $spacer.setAttribute('id', 'references-pane-spacer');
+
+    this.$pane = document.createElement('div');
+    this.$pane.setAttribute('id', 'references-pane');
+
+    this.$container.appendChild($spacer);
+    this.$container.appendChild(this.$pane);
+
+    this.$header = document.createElement('div');
+    this.$header.classList.add('menu-pane-header');
+    this.$header.textContent = 'References to ';
+    this.$headerRefId = document.createElement('a');
+    this.$header.appendChild(this.$headerRefId);
+    this.$closeButton = document.createElement('span');
+    this.$closeButton.setAttribute('id', 'references-pane-close');
+    this.$closeButton.addEventListener('click', function (e) {
+      this.deactivate();
+    }.bind(this));
+    this.$header.appendChild(this.$closeButton);
+
+    this.$pane.appendChild(this.$header);
+    var tableContainer = document.createElement('div');
+    tableContainer.setAttribute('id', 'references-pane-table-container');
+
+    this.$table = document.createElement('table');
+    this.$table.setAttribute('id', 'references-pane-table');
+
+    this.$tableBody = this.$table.createTBody();
+
+    tableContainer.appendChild(this.$table);
+    this.$pane.appendChild(tableContainer);
+
+    menu.$specContainer.appendChild(this.$container);
+  },
+
+  activate: function () {
+    this.$container.classList.add('active');
+  },
+
+  deactivate: function () {
+    this.$container.classList.remove('active');
+  },
+
+  showReferencesFor(entry) {
+    this.activate();
+    var newBody = document.createElement('tbody');
+    var previousId;
+    var previousCell;
+    var dupCount = 0;
+    this.$headerRefId.textContent = '#' + entry.id;
+    this.$headerRefId.setAttribute('href', '#' + entry.id);
+    entry.referencingIds.map(function (id) {
+      var target = document.getElementById(id);
+      var cid = findParentClauseId(target);
+      var clause = menu.search.biblio.byId[cid];
+      return { id: id, clause: clause }
+    }).sort(function (a, b) {
+      return sortByClauseNumber(a.clause, b.clause);
+    }).forEach(function (record, i) {
+      if (previousId === record.clause.id) {
+        previousCell.innerHTML += ' (<a href="#' + record.id + '">' + (dupCount + 2) + '</a>)';
+        dupCount++;
+      } else {
+        var row = newBody.insertRow();
+        var cell = row.insertCell();
+        cell.innerHTML = record.clause.number;
+        cell = row.insertCell();
+        cell.innerHTML = '<a href="#' + record.id + '">' + record.clause.titleHTML + '</a>';
+        previousCell = cell;
+        previousId = record.clause.id;
+        dupCount = 0;
+      }
+    }, this);
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+  }
+}
+function findParentClauseId(node) {
+  while (node && node.nodeName !== 'EMU-CLAUSE' && node.nodeName !== 'EMU-INTRO' && node.nodeName !== 'EMU-ANNEX') {
+    node = node.parentNode;
+  }
+  if (!node) return null;
+  return node.getAttribute('id');
+}
+
+function sortByClauseNumber(c1, c2) {
+  var c1c = c1.number.split('.');
+  var c2c = c2.number.split('.');
+
+  for (var i = 0; i < c1c.length; i++) {
+    if (i >= c2c.length) {
+      return 1;
+    }
+
+    var c1 = c1c[i];
+    var c2 = c2c[i];
+    var c1cn = Number(c1);
+    var c2cn = Number(c2);
+
+    if (Number.isNaN(c1cn) && Number.isNaN(c2cn)) {
+      if (c1 > c2) {
+        return 1;
+      } else if (c1 < c2) {
+        return -1;
+      }
+    } else if (!Number.isNaN(c1cn) && Number.isNaN(c2cn)) {
+      return -1;
+    } else if (Number.isNaN(c1cn) && !Number.isNaN(c2cn)) {
+      return 1;
+    } else if(c1cn > c2cn) {
+      return 1;
+    } else if (c1cn < c2cn) {
+      return -1;
+    }
+  }
+
+  if (c1c.length === c2c.length) {
+    return 0;
+  }
+  return -1;
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  Toolbox.init();
+  referencePane.init();
+})
+var CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
+function findLocalReferences ($elem) {
+  var name = $elem.innerHTML;
+  var references = [];
+
+  var parentClause = $elem.parentNode;
+  while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
+    parentClause = parentClause.parentNode;
+  }
+
+  if(!parentClause) return;
+
+  var vars = parentClause.querySelectorAll('var');
+
+  for (var i = 0; i < vars.length; i++) {
+    var $var = vars[i];
+
+    if ($var.innerHTML === name) {
+      references.push($var);
+    }
+  }
+
+  return references;
+}
+
+function toggleFindLocalReferences($elem) {
+  var references = findLocalReferences($elem);
+  if ($elem.classList.contains('referenced')) {
+    references.forEach(function ($reference) {
+      $reference.classList.remove('referenced');
+    });
+  } else {
+    references.forEach(function ($reference) {
+      $reference.classList.add('referenced');
+    });
+  }
+}
+
+function installFindLocalReferences () {
+  document.addEventListener('click', function (e) {
+    if (e.target.nodeName === 'VAR') {
+      toggleFindLocalReferences(e.target);
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', installFindLocalReferences);

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,0 +1,384 @@
+<!doctype html>
+<head><meta charset="utf-8">
+<script src="ecmarkup.js"></script>
+<link rel="stylesheet" href="ecmarkup.css">
+<title>Import Attributes</title>
+<script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"intro","aoid":null,"title":"Import Attributes","titleHTML":"Import Attributes","number":"","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","referencingIds":[],"key":"Import Attributes"},{"type":"production","id":"prod-ImportDeclaration","name":"ImportDeclaration","referencingIds":["_ref_57","_ref_58"],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"ImportDeclaration"},{"type":"production","id":"prod-ExportDeclaration","name":"ExportDeclaration","referencingIds":[],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"ExportDeclaration"},{"type":"production","id":"prod-AttributesClause","name":"AttributesClause","referencingIds":["_ref_41","_ref_42","_ref_43","_ref_49","_ref_59","_ref_60","_ref_67","_ref_68"],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"AttributesClause"},{"type":"production","id":"prod-AttributeEntries","name":"AttributeEntries","referencingIds":["_ref_44","_ref_46","_ref_51","_ref_53"],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"AttributeEntries"},{"type":"production","id":"prod-AttributeEntry","name":"AttributeEntry","referencingIds":["_ref_45","_ref_47","_ref_52","_ref_54"],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"AttributeEntry"},{"type":"production","id":"prod-AttributeKey","name":"AttributeKey","referencingIds":["_ref_48","_ref_55","_ref_56"],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"AttributeKey"},{"type":"production","id":"prod-ImportCall","name":"ImportCall","referencingIds":["_ref_50"],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"ImportCall"},{"type":"clause","id":"sec-syntax","aoid":null,"title":"Syntax","titleHTML":"Syntax","number":"1","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","referencingIds":[],"key":"Syntax"},{"type":"clause","id":"sec-evaluate-import-call","aoid":null,"title":"EvaluateImportCall ( specifierExpression [ , optionsExpression ] )","titleHTML":"EvaluateImportCall ( <var>specifierExpression</var> [ , <var>optionsExpression</var> ] )","number":"2.1.1.1","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","referencingIds":[],"key":"EvaluateImportCall ( specifierExpression [ , optionsExpression ] )"},{"type":"clause","id":"sec-import-call-runtime-semantics-evaluation","aoid":null,"title":"Runtime Semantics: Evaluation","titleHTML":"Runtime Semantics: Evaluation","number":"2.1.1","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","referencingIds":[],"key":"Runtime Semantics: Evaluation"},{"type":"clause","id":"sec-import-calls","aoid":null,"title":"Import Calls","titleHTML":"Import Calls","number":"2.1","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","referencingIds":["_ref_0"],"key":"Import Calls"},{"type":"op","aoid":"HostLoadImportedModule","refId":"sec-hostloadimportedmodule","location":"","referencingIds":[],"key":"HostLoadImportedModule"},{"type":"clause","id":"sec-hostloadimportedmodule","aoid":"HostLoadImportedModule","title":"HostLoadImportedModule ( referrer, specifiermoduleRequest, hostDefined, payload )","titleHTML":"HostLoadImportedModule ( <var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>hostDefined</var>, <var>payload</var> )","number":"2.2","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","referencingIds":["_ref_21","_ref_38"],"key":"HostLoadImportedModule ( referrer, specifiermoduleRequest, hostDefined, payload )"},{"type":"clause","id":"sec-FinishLoadingImportedModule","aoid":null,"title":"FinishLoadingImportedModule ( referrer, specifiermoduleRequest, payload, result )","titleHTML":"FinishLoadingImportedModule ( <var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var> )","number":"2.3","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","referencingIds":[],"key":"FinishLoadingImportedModule ( referrer, specifiermoduleRequest, payload, result )"},{"type":"op","aoid":"CollectImportAttributes","refId":"sec-collect-import-attributes","location":"","referencingIds":[],"key":"CollectImportAttributes"},{"type":"clause","id":"sec-collect-import-attributes","aoid":"CollectImportAttributes","title":"Static Semantics: CollectImportAttributes ( moduleRequest )","titleHTML":"Static Semantics: CollectImportAttributes ( <var>moduleRequest</var> )","number":"2.4","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","referencingIds":["_ref_24","_ref_25","_ref_34","_ref_37"],"key":"Static Semantics: CollectImportAttributes ( moduleRequest )"},{"type":"term","term":"ModuleRequest Record","refId":"sec-modulerequest-record","referencingIds":[],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"ModuleRequest Record"},{"type":"table","id":"table-modulerequest-fields","number":1,"caption":"Table 1: ModuleRequest Record fields","referencingIds":[],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"Table 1: ModuleRequest Record fields"},{"type":"clause","id":"sec-modulerequest-record","aoid":null,"title":"ModuleRequest Records","titleHTML":"ModuleRequest Records","number":"2.5","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","referencingIds":["_ref_8","_ref_22","_ref_23","_ref_26","_ref_27","_ref_30","_ref_31","_ref_32","_ref_33","_ref_35","_ref_36","_ref_39","_ref_40"],"key":"ModuleRequest Records"},{"type":"table","id":"table-cyclic-module-fields","number":2,"caption":"Table 2: Additional Fields of Cyclic Module Records","referencingIds":[],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"Table 2: Additional Fields of Cyclic Module Records"},{"type":"term","term":"ImportEntry Record","refId":"sec-semantics","referencingIds":["_ref_28","_ref_29"],"id":"importentry-record","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"ImportEntry Record"},{"type":"table","id":"table-39","number":3,"caption":"Table 3: ImportEntry Record Fields","referencingIds":["_ref_1"],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"Table 3: ImportEntry Record Fields"},{"type":"production","id":"prod-Module","name":"Module","referencingIds":[],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"Module"},{"type":"production","id":"prod-ModuleItemList","name":"ModuleItemList","referencingIds":["_ref_63","_ref_65"],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"ModuleItemList"},{"type":"production","id":"prod-ModuleItem","name":"ModuleItem","referencingIds":["_ref_61","_ref_62","_ref_64","_ref_66"],"namespace":"https://github.com/tc39/proposal-import-assertions","location":"","key":"ModuleItem"},{"type":"clause","id":"sec-static-semantics-modulerequests","aoid":null,"title":"Static Semantics: ModuleRequests","titleHTML":"Static Semantics: ModuleRequests","number":"2.6","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","referencingIds":[],"key":"Static Semantics: ModuleRequests"},{"type":"clause","id":"sec-semantics","aoid":null,"title":"Semantics","titleHTML":"Semantics","number":"2","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","referencingIds":[],"key":"Semantics"},{"type":"clause","id":"sec-host-integration","aoid":null,"title":"Sample host integration: The Web embedding","titleHTML":"Sample host integration: The Web embedding","number":"A","namespace":"https://github.com/tc39/proposal-import-assertions","location":"","referencingIds":[],"key":"Sample host integration: The Web embedding"}]</script></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#intro" title="Import Attributes">Import Attributes</a></li><li><span class="item-toggle-none"></span><a href="#sec-syntax" title="Syntax"><span class="secnum">1</span> Syntax</a></li><li><span class="item-toggle">◢</span><a href="#sec-semantics" title="Semantics"><span class="secnum">2</span> Semantics</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-import-calls" title="Import Calls"><span class="secnum">2.1</span> Import Calls</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-import-call-runtime-semantics-evaluation" title="Runtime Semantics: Evaluation"><span class="secnum">2.1.1</span> RS: Evaluation</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-evaluate-import-call" title="EvaluateImportCall ( specifierExpression [ , optionsExpression ] )"><span class="secnum">2.1.1.1</span> EvaluateImportCall ( <var>specifierExpression</var> [ , <var>optionsExpression</var> ] )</a></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-hostloadimportedmodule" title="HostLoadImportedModule ( referrer, specifiermoduleRequest, hostDefined, payload )"><span class="secnum">2.2</span> HostLoadImportedModule ( <var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>hostDefined</var>, <var>payload</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-FinishLoadingImportedModule" title="FinishLoadingImportedModule ( referrer, specifiermoduleRequest, payload, result )"><span class="secnum">2.3</span> FinishLoadingImportedModule ( <var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-collect-import-attributes" title="Static Semantics: CollectImportAttributes ( moduleRequest )"><span class="secnum">2.4</span> SS: CollectImportAttributes ( <var>moduleRequest</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-modulerequest-record" title="ModuleRequest Records"><span class="secnum">2.5</span> ModuleRequest Records</a></li><li><span class="item-toggle-none"></span><a href="#sec-static-semantics-modulerequests" title="Static Semantics: ModuleRequests"><span class="secnum">2.6</span> SS: ModuleRequests</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-host-integration" title="Sample host integration: The Web embedding"><span class="secnum">A</span> Sample host integration: The Web embedding</a></li></ol></div></div><div id="spec-container"><h1 class="version first">Stage 3 Draft / January 22, 2023</h1>
+<emu-intro id="intro">
+  <h1>Import Attributes</h1>
+  <p>Import Attributes are an extension to the import syntax that allows specifying additional information to affect how the module is imported. This proposal, other than defining such syntax, also defines the first import attribtue: <code>type</code>, which is passed to the host to specify the expected type of the loaded module. See <a href="https://github.com/tc39/proposal-import-assertions/blob/master/README.md">the explainer</a> for more information.</p>
+  <p>
+    Possible future extensions include:
+    </p><ul>
+      <li>a <code>module</code> attribute, to import an object representing the dependency's <emu-xref href="#sec-abstract-module-records"><a href="https://tc39.es/ecma262/#sec-abstract-module-records">Module Record</a></emu-xref> instead of evaluating it;</li>
+      <li>a <code>defer</code> attribute, to import a module without evaluating it immediately.</li>
+    </ul>
+  <p></p>
+  <p>Not every import attribute needs to interact with host semantics, for example <code>module</code> and <code>defer</code> could be defined completely within ECMA-262.</p>
+</emu-intro>
+
+<emu-clause id="sec-syntax">
+  <h1><span class="secnum">1</span> Syntax</h1>
+
+  <emu-grammar><emu-production name="ImportDeclaration" id="prod-ImportDeclaration">
+    <emu-nt><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="1a51d4c5"><emu-t>import</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-ImportClause">ImportClause</a></emu-nt><emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt><emu-t>;</emu-t></emu-rhs>
+    <emu-rhs a="a1d094cc"><emu-t>import</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt><emu-t>;</emu-t></emu-rhs>
+    <ins><emu-rhs a="93b8b2d7"><emu-t>import</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-ImportClause">ImportClause</a></emu-nt><emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt><emu-gann>[no <emu-nt><a href="https://tc39.es/ecma262/#prod-LineTerminator">LineTerminator</a></emu-nt> here]</emu-gann><emu-nt id="_ref_41"><a href="#prod-AttributesClause">AttributesClause</a></emu-nt><emu-t>;</emu-t></emu-rhs></ins>
+    <ins><emu-rhs a="76e665a8"><emu-t>import</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt><emu-gann>[no <emu-nt><a href="https://tc39.es/ecma262/#prod-LineTerminator">LineTerminator</a></emu-nt> here]</emu-gann><emu-nt id="_ref_42"><a href="#prod-AttributesClause">AttributesClause</a></emu-nt><emu-t>;</emu-t></emu-rhs></ins>
+</emu-production>
+<emu-production name="ExportDeclaration" id="prod-ExportDeclaration">
+    <emu-nt><a href="#prod-ExportDeclaration">ExportDeclaration</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="e0a40575"><emu-t>export</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-ExportFromClause">ExportFromClause</a></emu-nt><emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt><emu-t>;</emu-t></emu-rhs>
+    <ins><emu-rhs a="a16a041d"><emu-t>export</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-ExportFromClause">ExportFromClause</a></emu-nt><emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt><emu-gann>[no <emu-nt><a href="https://tc39.es/ecma262/#prod-LineTerminator">LineTerminator</a></emu-nt> here]</emu-gann><emu-nt id="_ref_43"><a href="#prod-AttributesClause">AttributesClause</a></emu-nt><emu-t>;</emu-t></emu-rhs></ins>
+    <emu-rhs a="2762c7fe"><emu-t>export</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-NamedExports">NamedExports</a></emu-nt><emu-t>;</emu-t></emu-rhs>
+    <emu-rhs a="696b8d6e"><emu-t>export</emu-t><emu-nt params="~Yield, ~Await"><a href="https://tc39.es/ecma262/#prod-VariableStatement">VariableStatement</a><emu-mods><emu-params>[~Yield, ~Await]</emu-params></emu-mods></emu-nt></emu-rhs>
+    <emu-rhs a="6bc99b97"><emu-t>export</emu-t><emu-nt params="~Yield, ~Await"><a href="https://tc39.es/ecma262/#prod-Declaration">Declaration</a><emu-mods><emu-params>[~Yield, ~Await]</emu-params></emu-mods></emu-nt></emu-rhs>
+    <emu-rhs a="d298e1ba"><emu-t>export</emu-t><emu-t>default</emu-t><emu-nt params="~Yield, ~Await, +Default"><a href="https://tc39.es/ecma262/#prod-HoistableDeclaration">HoistableDeclaration</a><emu-mods><emu-params>[~Yield, ~Await, +Default]</emu-params></emu-mods></emu-nt></emu-rhs>
+    <emu-rhs a="ae276654"><emu-t>export</emu-t><emu-t>default</emu-t><emu-nt params="~Yield, ~Await, +Default"><a href="https://tc39.es/ecma262/#prod-ClassDeclaration">ClassDeclaration</a><emu-mods><emu-params>[~Yield, ~Await, +Default]</emu-params></emu-mods></emu-nt></emu-rhs>
+    <emu-rhs a="e2a585b6"><emu-t>export</emu-t><emu-t>default</emu-t><emu-gann>[lookahead ∉ { <emu-t>function</emu-t>, <emu-t>async</emu-t>
+        <emu-gann>[no <emu-nt><a href="https://tc39.es/ecma262/#prod-LineTerminator">LineTerminator</a></emu-nt> here]</emu-gann>
+        <emu-t>function</emu-t>, <emu-t>class</emu-t> }]</emu-gann><emu-nt params="+In, ~Yield, ~Await"><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a><emu-mods><emu-params>[+In, ~Yield, ~Await]</emu-params></emu-mods></emu-nt><emu-t>;</emu-t></emu-rhs>
+</emu-production>
+<emu-production name="AttributesClause" id="prod-AttributesClause">
+    <emu-nt><a href="#prod-AttributesClause">AttributesClause</a></emu-nt><emu-geq>:</emu-geq><ins><emu-rhs a="1762e5de"><emu-t>with</emu-t><emu-t>{</emu-t><emu-t>}</emu-t></emu-rhs></ins>
+    <ins><emu-rhs a="af170d01"><emu-t>with</emu-t><emu-t>{</emu-t><emu-nt id="_ref_44"><a href="#prod-AttributeEntries">AttributeEntries</a></emu-nt><emu-t optional="">,<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t><emu-t>}</emu-t></emu-rhs></ins>
+</emu-production>
+<emu-production name="AttributeEntries" id="prod-AttributeEntries">
+    <emu-nt><a href="#prod-AttributeEntries">AttributeEntries</a></emu-nt><emu-geq>:</emu-geq><ins><emu-rhs a="000f6f84"><emu-nt id="_ref_45"><a href="#prod-AttributeEntry">AttributeEntry</a></emu-nt></emu-rhs></ins>
+    <ins><emu-rhs a="57521f76"><emu-nt id="_ref_46"><a href="#prod-AttributeEntries">AttributeEntries</a></emu-nt><emu-t>,</emu-t><emu-nt id="_ref_47"><a href="#prod-AttributeEntry">AttributeEntry</a></emu-nt></emu-rhs></ins>
+</emu-production>
+<emu-production name="AttributeEntry" id="prod-AttributeEntry">
+    <emu-nt><a href="#prod-AttributeEntry">AttributeEntry</a></emu-nt><emu-geq>:</emu-geq><ins><emu-rhs a="28cefc1e"><emu-nt id="_ref_48"><a href="#prod-AttributeKey">AttributeKey</a></emu-nt><emu-t>:</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-StringLiteral">StringLiteral</a></emu-nt></emu-rhs>
+    </ins>
+</emu-production>
+<emu-production name="AttributeKey" id="prod-AttributeKey">
+    <emu-nt><a href="#prod-AttributeKey">AttributeKey</a></emu-nt><emu-geq>:</emu-geq><ins><emu-rhs a="0ebb31e2"><emu-nt><a href="https://tc39.es/ecma262/#prod-IdentifierName">IdentifierName</a></emu-nt></emu-rhs></ins>
+    <ins><emu-rhs a="5c74e54d"><emu-nt><a href="https://tc39.es/ecma262/#prod-StringLiteral">StringLiteral</a></emu-nt></emu-rhs></ins>
+</emu-production>
+<emu-production name="ImportCall" params="Yield, Await" id="prod-ImportCall">
+    <emu-nt params="Yield, Await"><a href="#prod-ImportCall">ImportCall</a><emu-mods><emu-params>[Yield, Await]</emu-params></emu-mods></emu-nt><emu-geq>:</emu-geq><emu-rhs a="9710d64c"><emu-t>import</emu-t><emu-t>(</emu-t><emu-nt params="+In, ?Yield, ?Await"><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a><emu-mods><emu-params>[+In, ?Yield, ?Await]</emu-params></emu-mods></emu-nt><ins><emu-t optional="">,<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t></ins><emu-t>)</emu-t></emu-rhs>
+    <ins><emu-rhs a="571c9520"><emu-t>import</emu-t><emu-t>(</emu-t><emu-nt params="+In, ?Yield, ?Await"><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a><emu-mods><emu-params>[+In, ?Yield, ?Await]</emu-params></emu-mods></emu-nt><emu-t>,</emu-t><emu-nt params="+In, ?Yield, ?Await"><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a><emu-mods><emu-params>[+In, ?Yield, ?Await]</emu-params></emu-mods></emu-nt><emu-t optional="">,<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t><emu-t>)</emu-t></emu-rhs></ins>
+</emu-production></emu-grammar>
+</emu-clause>
+
+<emu-clause id="sec-semantics">
+  <h1><span class="secnum">2</span> Semantics</h1>
+
+  <emu-note type="editor"><span class="note">Editor's Note</span><div class="note-contents"><p>Many productions operating on grammar are the same whether or not an <emu-nt id="_ref_49"><a href="#prod-AttributesClause">AttributesClause</a></emu-nt>/second <emu-nt id="_ref_50"><a href="#prod-ImportCall">ImportCall</a></emu-nt> parameter is included; the new parameter is ignored. In this section, only the semantically significant changes are included, and the PR to merge into the main specification would fill in the straightforward details.</p></div></emu-note>
+
+    <emu-clause id="sec-import-calls">
+      <h1><span class="secnum">2.1</span> Import Calls</h1>
+
+      <emu-clause id="sec-import-call-runtime-semantics-evaluation">
+        <h1><span class="secnum">2.1.1</span> Runtime Semantics: Evaluation</h1>
+
+        <emu-clause id="sec-evaluate-import-call">
+          <h1><span class="secnum">2.1.1.1</span> EvaluateImportCall ( <var>specifierExpression</var> [ , <var>optionsExpression</var> ] )</h1>
+          <emu-alg><ol><li>Let <var>referencingScriptOrModule</var> be !&nbsp;<emu-xref aoid="GetActiveScriptOrModule" id="_ref_2"><a href="https://tc39.es/ecma262/#sec-getactivescriptormodule">GetActiveScriptOrModule</a></emu-xref>().</li><li>Let <var>specifierRef</var> be the result of evaluating <var>specifierExpression</var>.</li><li>Let <var>specifier</var> be ?&nbsp;<emu-xref aoid="GetValue" id="_ref_3"><a href="https://tc39.es/ecma262/#sec-getvalue">GetValue</a></emu-xref>(<var>specifierRef</var>).</li><li>If <var>optionsExpression</var> is present, then<ol><li>Let <var>optionsRef</var> be the result of evaluating <var>optionsExpression</var>.</li><li>Let <var>options</var> be ?&nbsp;<emu-xref aoid="GetValue" id="_ref_4"><a href="https://tc39.es/ecma262/#sec-getvalue">GetValue</a></emu-xref>(<var>optionsRef</var>).</li></ol></li><li>Else,<ol><li>Let <var>options</var> be <emu-val>undefined</emu-val>.</li></ol></li><li>Let <var>promiseCapability</var> be !&nbsp;<emu-xref aoid="NewPromiseCapability" id="_ref_5"><a href="https://tc39.es/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(<emu-xref href="#sec-promise-constructor"><a href="https://tc39.es/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</li><li>Let <var>specifierString</var> be <emu-xref aoid="ToString" id="_ref_6"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>specifier</var>).</li><li><emu-xref aoid="IfAbruptRejectPromise" id="_ref_7"><a href="https://tc39.es/ecma262/#sec-ifabruptrejectpromise">IfAbruptRejectPromise</a></emu-xref>(<var>specifierString</var>, <var>promiseCapability</var>).</li><li>Let <var>moduleRequest</var> be a new <emu-xref href="#sec-modulerequest-record" id="_ref_8"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifier]]: <var>specifierString</var>, [[Type]]: <emu-const>empty</emu-const> }.</li><li>If <var>options</var> is not <emu-val>undefined</emu-val>, then<ol><li>If <emu-xref aoid="Type" id="_ref_9"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>options</var>) is not Object,<ol><li>Perform !&nbsp;<emu-xref aoid="Call" id="_ref_10"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Reject]], <emu-val>undefined</emu-val>, « a newly created <emu-val>TypeError</emu-val> object »).</li><li>Return <var>promiseCapability</var>.[[Promise]].</li></ol></li><li>Let <var>attributesObj</var> be <emu-xref aoid="Get" id="_ref_11"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>options</var>, <emu-val>"with"</emu-val>).</li><li><emu-xref aoid="IfAbruptRejectPromise" id="_ref_12"><a href="https://tc39.es/ecma262/#sec-ifabruptrejectpromise">IfAbruptRejectPromise</a></emu-xref>(<var>attributesObj</var>, <var>promiseCapability</var>).</li><li>If <var>attributesObj</var> is not <emu-val>undefined</emu-val>,<ol><li>If <emu-xref aoid="Type" id="_ref_13"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>attributesObj</var>) is not Object,<ol><li>Perform !&nbsp;<emu-xref aoid="Call" id="_ref_14"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Reject]], <emu-val>undefined</emu-val>, « a newly created <emu-val>TypeError</emu-val> object »).</li><li>Return <var>promiseCapability</var>.[[Promise]].</li></ol></li><li>Let <var>keys</var> be <emu-xref aoid="EnumerableOwnPropertyNames" id="_ref_15"><a href="https://tc39.es/ecma262/#sec-enumerableownpropertynames">EnumerableOwnPropertyNames</a></emu-xref>(<var>attributesObj</var>, <emu-const>key</emu-const>).</li><li><emu-xref aoid="IfAbruptRejectPromise" id="_ref_16"><a href="https://tc39.es/ecma262/#sec-ifabruptrejectpromise">IfAbruptRejectPromise</a></emu-xref>(<var>keys</var>, <var>promiseCapability</var>).</li><li>For each String <var>key</var> of <var>keys</var>,<ol><li>Let <var>value</var> be <emu-xref aoid="Get" id="_ref_17"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>attributesObj</var>, <var>key</var>).</li><li><emu-xref aoid="IfAbruptRejectPromise" id="_ref_18"><a href="https://tc39.es/ecma262/#sec-ifabruptrejectpromise">IfAbruptRejectPromise</a></emu-xref>(<var>value</var>, <var>promiseCapability</var>).</li><li>If <emu-xref aoid="Type" id="_ref_19"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>value</var>) is not String, then<ol><li>Perform !&nbsp;<emu-xref aoid="Call" id="_ref_20"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Reject]], <emu-val>undefined</emu-val>, « a newly created <emu-val>TypeError</emu-val> object »).</li><li>Return <var>promiseCapability</var>.[[Promise]].</li></ol></li><li>If <var>key</var> is <emu-val>"type"</emu-val>, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>moduleRequest</var>.[[Type]] is <emu-const>empty</emu-const>.</li><li>Set <var>moduleRequest</var>.[[Type]] to <var>value</var>.</li></ol></li><li>TODO: Throw on unknown keys?</li></ol></li></ol></li></ol></li><li>Perform <emu-xref aoid="HostLoadImportedModule" id="_ref_21"><a href="#sec-hostloadimportedmodule">HostLoadImportedModule</a></emu-xref>(<var>referrer</var>, <var>moduleRequest</var>, <emu-const>empty</emu-const>, <var>promiseCapability</var>).</li><li>Return <var>promiseCapability</var>.[[Promise]].</li></ol></emu-alg>
+        </emu-clause>
+
+        <emu-grammar><emu-production name="ImportCall" collapsed="">
+    <emu-nt><a href="#prod-ImportCall">ImportCall</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="44ab2e9a"><emu-t>import</emu-t><emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt><emu-t optional="">,<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t><emu-t>)</emu-t></emu-rhs>
+</emu-production></emu-grammar>
+        <emu-alg><ol><li>Return ?&nbsp;EvaluateImportCall(<emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt>).</li></ol></emu-alg>
+
+        <ins><emu-grammar><emu-production name="ImportCall" collapsed="">
+    <emu-nt><a href="#prod-ImportCall">ImportCall</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="ee392673"><emu-t>import</emu-t><emu-t>(</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt><emu-t>,</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt><emu-t optional="">,<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t><emu-t>)</emu-t></emu-rhs>
+</emu-production></emu-grammar></ins>
+        <emu-alg><ol><li>Return ?&nbsp;EvaluateImportCall(the first <emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt>, the second <emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt>).</li></ol></emu-alg>
+      </emu-clause>
+    </emu-clause>
+
+      <emu-clause id="sec-hostloadimportedmodule" aoid="HostLoadImportedModule">
+        <h1><span class="secnum">2.2</span> HostLoadImportedModule ( <var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>hostDefined</var>, <var>payload</var> )</h1>
+        <p>The host-defined abstract operation HostLoadImportedModule takes arguments <var>referrer</var> (a <emu-xref href="#script-record"><a href="https://tc39.es/ecma262/#script-record">Script Record</a></emu-xref>, a <emu-xref href="#cyclic-module-record"><a href="https://tc39.es/ecma262/#cyclic-module-record">Cyclic Module Record</a></emu-xref>, or a <emu-xref href="#realm-record"><a href="https://tc39.es/ecma262/#realm-record">Realm Record</a></emu-xref>), <del><var>specifier</var> (a String)</del><ins><var>moduleRequest</var> (a <emu-xref href="#sec-modulerequest-record" id="_ref_22"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref>)</ins>, <var>hostDefined</var> (anything), and <var>payload</var> (a GraphLoadingState <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> or a PromiseCapability <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>) and returns <emu-const>unused</emu-const>.</p>
+
+        <emu-note><span class="note">Note</span><div class="note-contents">
+          <p>An example of when <var>referrer</var> can be a <emu-xref href="#realm-record"><a href="https://tc39.es/ecma262/#realm-record">Realm Record</a></emu-xref> is in a web browser host. There, if a user clicks on a control given by</p>
+
+          <pre><code class="html hljs"><span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"button"</span> <span class="hljs-attr">onclick</span>=<span class="hljs-string">"import('./foo.mjs')"</span>&gt;</span>Click me<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span></code></pre>
+
+          <p>there will be no active script or module at the time the <emu-xref href="#sec-import-calls" id="_ref_0"><a href="#sec-import-calls"><code>import()</code></a></emu-xref> expression runs. More generally, this can happen in any situation where the host pushes execution contexts with <emu-val>null</emu-val> ScriptOrModule components onto the <emu-xref href="#execution-context-stack"><a href="https://tc39.es/ecma262/#execution-context-stack">execution context stack</a></emu-xref>.</p>
+        </div></emu-note>
+
+        <p>An implementation of HostLoadImportedModule must conform to the following requirements:</p>
+        <ul>
+          <li>
+            The host environment must perform FinishLoadingImportedModule(<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var>), where <var>result</var> is either a normal completion containing the loaded <emu-xref href="#sec-abstract-module-records"><a href="https://tc39.es/ecma262/#sec-abstract-module-records">Module Record</a></emu-xref> or a throw completion, either synchronously or asynchronously.
+          </li>
+          <li>
+            <p>If this operation is called multiple times with the same <del>(<var>referrer</var>, <var>specifier</var>) pair</del><ins>(<var>referrer</var>, <var>moduleRequest</var>.[[Specifier]], <var>moduleRequest</var>.[[Type]]) triple</ins> and it performs FinishLoadingImportedModule(<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var>) where <var>result</var> is a normal completion, then it must perform FinishLoadingImportedModule(<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var>) with the same <var>result</var> each time.</p>
+          </li>
+          <li>
+            The operation must treat <var>payload</var> as an opaque value to be passed through to FinishLoadingImportedModule.
+          </li>
+        </ul>
+      </emu-clause>
+
+      <emu-clause id="sec-FinishLoadingImportedModule" type="abstract operation">
+        <h1><span class="secnum">2.3</span> FinishLoadingImportedModule ( <var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var> )</h1>
+        <p>The abstract operation FinishLoadingImportedModule takes arguments <var>referrer</var> (a <emu-xref href="#script-record"><a href="https://tc39.es/ecma262/#script-record">Script Record</a></emu-xref>, a <emu-xref href="#cyclic-module-record"><a href="https://tc39.es/ecma262/#cyclic-module-record">Cyclic Module Record</a></emu-xref>, or a <emu-xref href="#realm-record"><a href="https://tc39.es/ecma262/#realm-record">Realm Record</a></emu-xref>), <del><var>specifier</var> (a String)</del><ins><var>moduleRequest</var> (a <emu-xref href="#sec-modulerequest-record" id="_ref_23"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref>)</ins>, <var>payload</var> (a GraphLoadingState <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> or a PromiseCapability <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>), and <var>result</var> (either a normal completion containing a <emu-xref href="#sec-abstract-module-records"><a href="https://tc39.es/ecma262/#sec-abstract-module-records">Module Record</a></emu-xref> or a throw completion) and returns <emu-const>unused</emu-const>.</p>
+
+        <emu-alg><ol><li>If <var>result</var> is a normal completion, then<ol><li>If <var>referrer</var>.[[LoadedModules]] contains a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> <var>record</var> such that <var>record</var>.[[Specifier]] is <var>moduleRequest</var>.[[Specifier]] <ins>and <var>record</var>.[[Type]] is <var>moduleRequest</var>.[[Type]]</ins>, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>record</var>.[[Module]] is <var>result</var>.[[Value]].</li></ol></li><li>Else, add <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Specifier]]: <var>moduleRequest</var>.[[Specifier]], <ins>[[Type]]: <var>moduleRequest</var>.[[Type]]</ins>, [[Module]]: <var>result</var>.[[Value]] } to <var>referrer</var>.[[LoadedModules]].</li></ol></li><li>If <var>payload</var> is a GraphLoadingState <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>, then<ol><li>Perform ContinueModuleLoading(<var>payload</var>, <var>result</var>).</li></ol></li><li>Else,<ol><li>Perform ContinueDynamicImport(<var>payload</var>, <var>result</var>).</li></ol></li><li>Return <emu-const>unused</emu-const>.</li></ol></emu-alg>
+
+        <emu-note type="editor"><span class="note">Editor's Note</span><div class="note-contents">
+          <p>The description of the [[LoadedModules]] field of <emu-xref href="#realm-record"><a href="https://tc39.es/ecma262/#realm-record">Realm Record</a></emu-xref>, <emu-xref href="#script-record"><a href="https://tc39.es/ecma262/#script-record">Script Record</a></emu-xref>, and <emu-xref href="#cyclic-module-record"><a href="https://tc39.es/ecma262/#cyclic-module-record">Cyclic Module Record</a></emu-xref> should be updated to include the [[Type]] field.</p>
+        </div></emu-note>
+      </emu-clause>
+
+  <emu-clause id="sec-collect-import-attributes" aoid="CollectImportAttributes">
+    <h1><span class="secnum">2.4</span> Static Semantics: CollectImportAttributes ( <var>moduleRequest</var> )</h1>
+    <emu-grammar><emu-production name="AttributeEntries" collapsed="">
+    <emu-nt><a href="#prod-AttributeEntries">AttributeEntries</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="57521f76"><emu-nt id="_ref_51"><a href="#prod-AttributeEntries">AttributeEntries</a></emu-nt><emu-t>,</emu-t><emu-nt id="_ref_52"><a href="#prod-AttributeEntry">AttributeEntry</a></emu-nt></emu-rhs>
+</emu-production></emu-grammar>
+    <emu-alg><ol><li>Perform <emu-xref aoid="CollectImportAttributes" id="_ref_24"><a href="#sec-collect-import-attributes">CollectImportAttributes</a></emu-xref> of <emu-nt id="_ref_53"><a href="#prod-AttributeEntries">AttributeEntries</a></emu-nt> with parameters « <var>moduleRequest</var> ».</li><li>Perform <emu-xref aoid="CollectImportAttributes" id="_ref_25"><a href="#sec-collect-import-attributes">CollectImportAttributes</a></emu-xref> of <emu-nt id="_ref_54"><a href="#prod-AttributeEntry">AttributeEntry</a></emu-nt> with parameters « <var>moduleRequest</var> ».</li></ol></emu-alg>
+
+    <emu-grammar><emu-production name="AttributeEntry" collapsed="">
+    <emu-nt><a href="#prod-AttributeEntry">AttributeEntry</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="28cefc1e"><emu-nt id="_ref_55"><a href="#prod-AttributeKey">AttributeKey</a></emu-nt><emu-t>:</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-StringLiteral">StringLiteral</a></emu-nt></emu-rhs>
+</emu-production></emu-grammar>
+    <emu-alg><ol><li>Let <var>key</var> be StringValue of <emu-nt id="_ref_56"><a href="#prod-AttributeKey">AttributeKey</a></emu-nt>.</li><li>If <var>key</var> is <emu-val>"type"</emu-val>, then<ol><li>If <var>moduleRequest</var>.[[Type]] is not <emu-const>empty</emu-const>, throw a SyntaxError exception.</li><li>Set <var>moduleRequest</var>.[[Type]] to the StringValue of <emu-nt><a href="https://tc39.es/ecma262/#prod-StringLiteral">StringLiteral</a></emu-nt>.</li></ol></li><li>TODO: Throw on unknown keys?</li></ol></emu-alg>
+  </emu-clause>
+
+      <emu-clause id="sec-modulerequest-record">
+        <h1><span class="secnum">2.5</span> ModuleRequest Records</h1>
+
+        <p>A <dfn>ModuleRequest Record</dfn> represents the request to import a module with given import attributes. It consists of the following fields:</p>
+        <emu-table id="table-modulerequest-fields" caption="ModuleRequest Record fields"><figure><figcaption>Table 1: <emu-xref href="#sec-modulerequest-record" id="_ref_26"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref> fields</figcaption>
+          <table>
+            <tbody>
+              <tr>
+                <th>
+                  Field Name
+                </th>
+                <th>
+                  Value Type
+                </th>
+                <th>
+                  Meaning
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  [[Specifier]]
+                </td>
+                <td>
+                  String
+                </td>
+                <td>
+                  The module specifier
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  [[Type]]
+                </td>
+                <td>
+                  a String, or <emu-const>empty</emu-const>
+                </td>
+                <td>
+                  The <code>type</code> attribute of this import
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </figure></emu-table>
+
+        <emu-note type="editor"><span class="note">Editor's Note</span><div class="note-contents">In general, this proposal replaces places where module specifiers are passed around with ModuleRequest Records. For example, several syntax-directed operations, such as ModuleRequests produce Lists of ModuleRequest Records rather than Lists of Strings which are interpreted as module specifiers. Some algorithms like ImportEntries and ImportEntriesForModule pass around ModuleRequest Records rather than Strings, in a way which doesn't require any particular textual change. Additionally, record fields in Cyclic Module Records and Source Text Module Records which contained Lists of Strings are replaced by Lists of ModuleRequest Records, as indicated above.</div></emu-note>
+      </emu-clause>
+
+        <emu-table id="table-cyclic-module-fields" caption="Additional Fields of Cyclic Module Records"><figure><figcaption>Table 2: Additional Fields of Cyclic Module Records</figcaption>
+          <table>
+            <tbody>
+              <tr>
+                <th>
+                  Field Name
+                </th>
+                <th>
+                  Value Type
+                </th>
+                <th>
+                  Meaning
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  [[Status]]
+                </td>
+                <td>
+                  <emu-const>unlinked</emu-const> | <emu-const>linking</emu-const> | <emu-const>linked</emu-const> | <emu-const>evaluating</emu-const> | <emu-const>evaluated</emu-const>
+                </td>
+                <td>
+                  Initially <emu-const>unlinked</emu-const>. Transitions to <emu-const>linking</emu-const>, <emu-const>linked</emu-const>, <emu-const>evaluating</emu-const>, <emu-const>evaluated</emu-const> (in that order) as the module progresses throughout its lifecycle.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  [[EvaluationError]]
+                </td>
+                <td>
+                  An <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref> | <emu-val>undefined</emu-val>
+                </td>
+                <td>
+                  A completion of type <emu-const>throw</emu-const> representing the exception that occurred during evaluation.  <emu-val>undefined</emu-val> if no exception occurred or if [[Status]] is not <emu-const>evaluated</emu-const>.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  [[DFSIndex]]
+                </td>
+                <td>
+                  <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">Integer</a></emu-xref> | <emu-val>undefined</emu-val>
+                </td>
+                <td>
+                  Auxiliary field used during Link and Evaluate only.
+                  If [[Status]] is <emu-const>linking</emu-const> or <emu-const>evaluating</emu-const>, this nonnegative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  [[DFSAncestorIndex]]
+                </td>
+                <td>
+                  <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">Integer</a></emu-xref> | <emu-val>undefined</emu-val>
+                </td>
+                <td>
+                  Auxiliary field used during Link and Evaluate only. If [[Status]] is <emu-const>linking</emu-const> or <emu-const>evaluating</emu-const>, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  [[RequestedModules]]
+                </td>
+                <td>
+                  <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <del>String</del><ins><emu-xref href="#sec-modulerequest-record" id="_ref_27"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref></ins>
+                </td>
+                <td>
+                  A <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of all the <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt> strings <ins>with the corresponding <code>type</code> import attribute</ins> used by the module represented by this record to request the importation of a module. The <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> is source code occurrence ordered.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </figure></emu-table>
+
+        <p>An <dfn id="importentry-record">ImportEntry Record</dfn> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> that digests information about a single declarative import. Each <emu-xref href="#importentry-record" id="_ref_28"><a href="#importentry-record">ImportEntry Record</a></emu-xref> has the fields defined in <emu-xref href="#table-39" id="_ref_1"><a href="#table-39">Table 3</a></emu-xref>:</p>
+        <emu-table id="table-39" caption="ImportEntry Record Fields"><figure><figcaption>Table 3: <emu-xref href="#importentry-record" id="_ref_29"><a href="#importentry-record">ImportEntry Record</a></emu-xref> Fields</figcaption>
+          <table>
+            <tbody>
+            <tr>
+              <th>
+                Field Name
+              </th>
+              <th>
+                Value Type
+              </th>
+              <th>
+                Meaning
+              </th>
+            </tr>
+            <tr>
+              <td>
+                [[ModuleRequest]]
+              </td>
+              <td>
+                <del>String</del>
+                <ins><emu-xref href="#sec-modulerequest-record" id="_ref_30"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref></ins>
+              </td>
+              <td>
+                <del>String value of the <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt> of the <emu-nt id="_ref_57"><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt>.</del>
+                <ins><emu-xref href="#sec-modulerequest-record" id="_ref_31"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref> representing the <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt> and the <code>type</code> import attribute of the <emu-nt id="_ref_58"><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt>.</ins>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[ImportName]]
+              </td>
+              <td>
+                String
+              </td>
+              <td>
+                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value <emu-val>"*"</emu-val> indicates that the import request is for the target module's namespace object.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[LocalName]]
+              </td>
+              <td>
+                String
+              </td>
+              <td>
+                The name that is used to locally access the imported value from within the importing module.
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </figure></emu-table>
+
+      <emu-clause id="sec-static-semantics-modulerequests">
+        <h1><span class="secnum">2.6</span> Static Semantics: ModuleRequests</h1>
+        <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
+        <emu-grammar><emu-production name="ImportDeclaration" collapsed="">
+    <emu-nt><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="1a51d4c5"><emu-t>import</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-ImportClause">ImportClause</a></emu-nt><emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt><emu-t>;</emu-t></emu-rhs>
+</emu-production></emu-grammar>
+        <emu-alg><ol><li><del>Return ModuleRequests of <emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt>.</del></li><li><ins>Let <var>specifier</var> be StringValue of <emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt>.</ins></li><li><ins>Return a <emu-xref href="#sec-modulerequest-record" id="_ref_32"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifer]]: <var>specifier</var>, [[Type]]: <emu-const>empty</emu-const> }.</ins></li></ol></emu-alg>
+        <emu-grammar><emu-production name="ImportDeclaration" collapsed="">
+    <emu-nt><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="20cf3b93"><emu-t>import</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-ImportClause">ImportClause</a></emu-nt><emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt><emu-nt id="_ref_59"><a href="#prod-AttributesClause">AttributesClause</a></emu-nt><emu-t>;</emu-t></emu-rhs>
+</emu-production></emu-grammar>
+        <emu-alg><ol><li><ins>Let <var>specifier</var> be StringValue of <emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt>.</ins></li><li><ins>Let <var>request</var> be the <emu-xref href="#sec-modulerequest-record" id="_ref_33"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifer]]: <var>specifier</var>, [[Type]]: <emu-const>empty</emu-const> }.</ins></li><li><ins>Perform <emu-xref aoid="CollectImportAttributes" id="_ref_34"><a href="#sec-collect-import-attributes">CollectImportAttributes</a></emu-xref> of <emu-nt id="_ref_60"><a href="#prod-AttributesClause">AttributesClause</a></emu-nt> with argument <var>request</var>.</ins></li><li><ins>Return <var>request</var>.</ins></li></ol></emu-alg>
+        <emu-grammar><emu-production name="Module" collapsed="" id="prod-Module">
+    <emu-nt><a href="#prod-Module">Module</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="37b9c04c"><emu-gann>[empty]</emu-gann></emu-rhs>
+</emu-production></emu-grammar>
+        <emu-alg><ol><li>Return a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li></ol></emu-alg>
+        <emu-grammar><emu-production name="ModuleItemList" collapsed="" id="prod-ModuleItemList">
+    <emu-nt><a href="#prod-ModuleItemList">ModuleItemList</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="029ec31e"><emu-nt id="_ref_61"><a href="#prod-ModuleItem">ModuleItem</a></emu-nt></emu-rhs>
+</emu-production></emu-grammar>
+        <emu-alg><ol><li>Return ModuleRequests of <emu-nt id="_ref_62"><a href="#prod-ModuleItem">ModuleItem</a></emu-nt>.</li></ol></emu-alg>
+        <emu-grammar><emu-production name="ModuleItemList" collapsed="">
+    <emu-nt><a href="#prod-ModuleItemList">ModuleItemList</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="75ddb725"><emu-nt id="_ref_63"><a href="#prod-ModuleItemList">ModuleItemList</a></emu-nt><emu-nt id="_ref_64"><a href="#prod-ModuleItem">ModuleItem</a></emu-nt></emu-rhs>
+</emu-production></emu-grammar>
+        <emu-alg><ol><li>Let <var>moduleNames</var> be ModuleRequests of <emu-nt id="_ref_65"><a href="#prod-ModuleItemList">ModuleItemList</a></emu-nt>.</li><li>Let <var>additionalNames</var> be ModuleRequests of <emu-nt id="_ref_66"><a href="#prod-ModuleItem">ModuleItem</a></emu-nt>.</li><li>Append to <var>moduleNames</var> each element of <var>additionalNames</var> that is not already an element of <var>moduleNames</var>.</li><li>Return <var>moduleNames</var>.</li></ol></emu-alg>
+        <emu-grammar><emu-production name="ModuleItem" collapsed="" id="prod-ModuleItem">
+    <emu-nt><a href="#prod-ModuleItem">ModuleItem</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="d791d1c9"><emu-nt><a href="https://tc39.es/ecma262/#prod-StatementListItem">StatementListItem</a></emu-nt></emu-rhs>
+</emu-production></emu-grammar>
+        <emu-alg><ol><li>Return a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li></ol></emu-alg>
+        <emu-grammar><emu-production name="ExportDeclaration" collapsed="">
+    <emu-nt><a href="#prod-ExportDeclaration">ExportDeclaration</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="e0a40575"><emu-t>export</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-ExportFromClause">ExportFromClause</a></emu-nt><emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt><emu-t>;</emu-t></emu-rhs>
+</emu-production></emu-grammar>
+        <emu-alg><ol><li><del>Return ModuleRequests of <emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt>.</del></li><li><ins>Let <var>specifier</var> be StringValue of <emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt>.</ins></li><li><ins>Return the <emu-xref href="#sec-modulerequest-record" id="_ref_35"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifer]]: <var>specifier</var>, [[Type]]: <emu-const>empty</emu-const> }.</ins></li></ol></emu-alg>
+        <emu-grammar><emu-production name="ExportDeclaration" collapsed="">
+    <emu-nt><a href="#prod-ExportDeclaration">ExportDeclaration</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="6813ec6e"><emu-t>export</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-ExportFromClause">ExportFromClause</a></emu-nt><emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt><emu-nt id="_ref_67"><a href="#prod-AttributesClause">AttributesClause</a></emu-nt><emu-t>;</emu-t></emu-rhs>
+</emu-production></emu-grammar>
+        <emu-alg><ol><li><ins>Let <var>specifier</var> be StringValue of the <emu-nt><a href="https://tc39.es/ecma262/#prod-StringLiteral">StringLiteral</a></emu-nt> contained in <emu-nt><a href="https://tc39.es/ecma262/#prod-FromClause">FromClause</a></emu-nt>.</ins></li><li><ins>Let <var>request</var> be the <emu-xref href="#sec-modulerequest-record" id="_ref_36"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifer]]: <var>specifier</var>, [[Type]]: <emu-const>empty</emu-const> }.</ins></li><li><ins>Perform <emu-xref aoid="CollectImportAttributes" id="_ref_37"><a href="#sec-collect-import-attributes">CollectImportAttributes</a></emu-xref> of <emu-nt id="_ref_68"><a href="#prod-AttributesClause">AttributesClause</a></emu-nt> with argument <var>request</var>.</ins></li><li><ins>Return <var>request</var>.</ins></li></ol></emu-alg>
+        <emu-grammar><emu-production name="ExportDeclaration">
+    <emu-nt><a href="#prod-ExportDeclaration">ExportDeclaration</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="2762c7fe"><emu-t>export</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-NamedExports">NamedExports</a></emu-nt><emu-t>;</emu-t></emu-rhs>
+    <emu-rhs a="6c6de801"><emu-t>export</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-VariableStatement">VariableStatement</a></emu-nt></emu-rhs>
+    <emu-rhs a="828f5ae3"><emu-t>export</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-Declaration">Declaration</a></emu-nt></emu-rhs>
+    <emu-rhs a="71d1417e"><emu-t>export</emu-t><emu-t>default</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-HoistableDeclaration">HoistableDeclaration</a></emu-nt></emu-rhs>
+    <emu-rhs a="c3c3cb8d"><emu-t>export</emu-t><emu-t>default</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-ClassDeclaration">ClassDeclaration</a></emu-nt></emu-rhs>
+    <emu-rhs a="e1fe9c4f"><emu-t>export</emu-t><emu-t>default</emu-t><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt><emu-t>;</emu-t></emu-rhs>
+</emu-production></emu-grammar>
+        <emu-alg><ol><li>Return a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li></ol></emu-alg>
+      </emu-clause>
+</emu-clause>
+
+<emu-annex id="sec-host-integration">
+  <h1><span class="secnum">A</span> Sample host integration: The Web embedding</h1>
+
+  <p>The import attributes proposal is intended to give key information about how modules are interpreted to hosts. For the Web embedding and environments which aim to be similar to it, the string is interpreted as the "module type". This is not the primary way the module type is determined (which, on the Web, would be the MIME type, and in other environments may be the file extension), but rather a secondary check which is required to pass for the module graph to load.</p>
+
+  <p>In the Web embedding, the following changes would be made to the HTML specification for import attributes:</p>
+
+  <ul>
+    <li>The <a href="https://html.spec.whatwg.org/#module-script">module script</a> would have an additional item, which would be the module type, as a string (e.g., <emu-val>"json"</emu-val>), or <emu-val>undefined</emu-val> for a JavaScript module.</li>
+    <li><emu-xref aoid="HostLoadImportedModule" id="_ref_38"><a href="#sec-hostloadimportedmodule">HostLoadImportedModule</a></emu-xref> would take a <emu-xref href="#sec-modulerequest-record" id="_ref_39"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref> parameter in place of a specifier string, which would be passed down through several <emu-xref href="#sec-algorithm-conventions-abstract-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations">abstract operations</a></emu-xref> to reach the <a href="https://html.spec.whatwg.org/#fetch-a-single-module-script">fetch a single module script</a> algorithm. Somewhere near the entrypoint, if the <emu-xref href="#sec-modulerequest-record" id="_ref_40"><a href="#sec-modulerequest-record">ModuleRequest Record</a></emu-xref>'s [[Type]] field has an element <var>entry</var> such that <var>entry</var>.[[Key]] is <emu-val>"type"</emu-val>, then let <var>type</var> be <var>entry</var>.[[Value]]; otherwise let <var>type</var> be <emu-val>undefined</emu-val>. If the type is invalid, then an exception is thrown and module loading fails. Otherwise, this will equal the module type, if the module can be successfully fetched with a matching MIME type.</li>
+    <li>In the <a href="https://html.spec.whatwg.org/#fetch-the-descendants-of-a-module-script">fetch the descendents of a module script</a> algorithm, when iterating over [[RequestedModules]], the elements are ModuleRequest Records rather than just specifier strings; these Records is passed on to the internal module script graph fetching procedure (which sends it to "fetch a single module script". Other usage sites of [[RequestedModules]] ignore the assertion.</li>
+    <li>"Fetch a single module script" would check the assertion in two places:
+      <ul>
+        <li>The module map is keyed with both the absolute URL and the module type, so an existing entry will be found only if its <var>type</var> matches.</li>
+        <li>When a new module is fetched, before writing it into the module map, the MIME type is checked to ensure that it matches <var>type</var>. (Note that the interpretation of the module is still driven by the MIME type, but once the MIME type is established, this is checked against the <var>type</var>.) If they differ, then an exception is thrown and module loading fails. The <var>type</var> is written into the module script as the type.</li>
+      </ul>
+    </li>
+  </ul>
+
+  <p>The module map is keyed by the absolute URL and the <var>type</var>. Initially no other import attributes are supported, so they are not present.</p>
+</emu-annex>
+</div></body>

--- a/spec.html
+++ b/spec.html
@@ -2,9 +2,9 @@
 <meta charset="utf8">
 <script src="ecmarkup.js"></script>
 <link rel="stylesheet" href="ecmarkup.css">
-<title>import assertions</title>
+<title>import attributes</title>
 <pre class=metadata>
-  title: Import assertions
+  title: Import attributes
   status: proposal
   stage: 3
   location: https://github.com/tc39/proposal-import-assertions
@@ -12,7 +12,7 @@
   contributors: Sven Sauleau, Myles Borins, Daniel Ehrenberg, Daniel Clark
 </pre>
 <emu-intro id="intro">
-  <h1>import assertions</h1>
+  <h1>import attributes</h1>
   <p>See <a href="https://github.com/tc39/proposal-import-assertions/blob/master/README.md">the explainer</a> for information.</p>
 </emu-intro>
 
@@ -23,12 +23,12 @@
     ImportDeclaration :
       `import` ImportClause FromClause `;`
       `import` ModuleSpecifier `;`
-      <ins>`import` ImportClause FromClause [no LineTerminator here] AssertClause `;`</ins>
-      <ins>`import` ModuleSpecifier [no LineTerminator here] AssertClause `;`</ins>
+      <ins>`import` ImportClause FromClause [no LineTerminator here] AttributesClause `;`</ins>
+      <ins>`import` ModuleSpecifier [no LineTerminator here] AttributesClause `;`</ins>
 
     ExportDeclaration :
       `export` ExportFromClause FromClause `;`
-      <ins>`export` ExportFromClause FromClause [no LineTerminator here] AssertClause `;`</ins>
+      <ins>`export` ExportFromClause FromClause [no LineTerminator here] AttributesClause `;`</ins>
       `export` NamedExports `;`
       `export` VariableStatement[~Yield, ~Await]
       `export` Declaration[~Yield, ~Await]
@@ -36,15 +36,15 @@
       `export` `default` ClassDeclaration[~Yield, ~Await, +Default]
       `export` `default` [lookahead &lt;! {`function`, `async` [no |LineTerminator| here] `function`, `class`}] AssignmentExpression[+In, ~Yield, ~Await] `;`
 
-    AssertClause :
+    AttributesClause :
       <ins>`assert` `{` `}`</ins>
-      <ins>`assert` `{` AssertEntries `,`? `}`</ins>
+      <ins>`assert` `{` AttributeEntries `,`? `}`</ins>
 
-    AssertEntries :
-      <ins>AssertionKey `:` StringLiteral</ins>
-      <ins>AssertionKey `:` StringLiteral `,` AssertEntries</ins>
+    AttributeEntries :
+      <ins>AttributeKey `:` StringLiteral</ins>
+      <ins>AttributeKey `:` StringLiteral `,` AttributeEntries</ins>
 
-    AssertionKey:
+    AttributeKey:
       <ins>IdentifierName</ins>
       <ins>StringLiteral</ins>
 
@@ -57,7 +57,7 @@
 <emu-clause id="sec-semantics">
   <h1>Semantics</h1>
 
-  <emu-note type="editor"><p>Many productions operating on grammar are the same whether or not an |AssertClause|/second |ImportCall| parameter is included; the new parameter is ignored. In this section, only the semantically significant changes are included, and the PR to merge into the main specification would fill in the straightforward details.</p></emu-note>
+  <emu-note type="editor"><p>Many productions operating on grammar are the same whether or not an |AttributesClause|/second |ImportCall| parameter is included; the new parameter is ignored. In this section, only the semantically significant changes are included, and the PR to merge into the main specification would fill in the straightforward details.</p></emu-note>
 
     <emu-clause id="sec-import-calls">
       <h1>Import Calls</h1>
@@ -79,30 +79,30 @@
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. Let _specifierString_ be ToString(_specifier_).
             1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
-            1. Let _assertions_ be a new empty List.
+            1. Let _attributes_ be a new empty List.
             1. If _options_ is not *undefined*, then
               1. If Type(_options_) is not Object,
                 1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
                 1. Return _promiseCapability_.[[Promise]].
-              1. Let _assertionsObj_ be Get(_options_, *"assert"*).
-              1. IfAbruptRejectPromise(_assertionsObj_, _promiseCapability_).
-              1. If _assertionsObj_ is not *undefined*,
-                1. If Type(_assertionsObj_) is not Object,
+              1. Let _attributesObj_ be Get(_options_, *"assert"*).
+              1. IfAbruptRejectPromise(_attributesObj_, _promiseCapability_).
+              1. If _attributesObj_ is not *undefined*,
+                1. If Type(_attributesObj_) is not Object,
                   1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
                   1. Return _promiseCapability_.[[Promise]].
-                1. Let _keys_ be EnumerableOwnPropertyNames(_assertionsObj_, ~key~).
+                1. Let _keys_ be EnumerableOwnPropertyNames(_attributesObj_, ~key~).
                 1. IfAbruptRejectPromise(_keys_, _promiseCapability_).
-                1. Let _supportedAssertions_ be ! HostGetSupportedImportAssertions().
+                1. Let _supportedAttributes_ be ! HostGetSupportedImportAttributes().
                 1. For each String _key_ of _keys_,
-                  1. Let _value_ be Get(_assertionsObj_, _key_).
+                  1. Let _value_ be Get(_attributesObj_, _key_).
                   1. IfAbruptRejectPromise(_value_, _promiseCapability_).
                   1. If Type(_value_) is not String, then
                     1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
                     1. Return _promiseCapability_.[[Promise]].
-                  1. If _supportedAssertions_ contains _key_, then
-                    1. Append { [[Key]]: _key_, [[Value]]: _value_ } to _assertions_.
-              1. Sort _assertions_ by the code point order of the [[Key]] of each element. NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among assertions by the order they occur in.
-            1. Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Assertions]]: _assertions_ }.
+                  1. If _supportedAttributes_ contains _key_, then
+                    1. Append { [[Key]]: _key_, [[Value]]: _value_ } to _attributes_.
+              1. Sort _attributes_ by the code point order of the [[Key]] of each element. NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among attributes by the order they occur in.
+            1. Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Attributes]]: _attributes_ }.
             1. Perform HostLoadImportedModule(_referrer_, _moduleRequest_, ~empty~, _promiseCapability_).
             1. Return _promiseCapability_.[[Promise]].
           </emu-alg>
@@ -138,7 +138,7 @@
             The host environment must perform FinishLoadingImportedModule(_referrer_, <del>_specifier_</del><ins>_moduleRequest_</ins>, _payload_, _result_), where _result_ is either a normal completion containing the loaded Module Record or a throw completion, either synchronously or asynchronously.
           </li>
           <li>
-            <p>If this operation is called multiple times with the same <del>(_referrer_, _specifier_) pair</del><ins>(_referrer_, _moduleRequest_.[[Specifier]], _moduleRequest_.[[Assertions]]) triple</ins> and it performs FinishLoadingImportedModule(_referrer_, <del>_specifier_</del><ins>_moduleRequest_</ins>, _payload_, _result_) where _result_ is a normal completion, then it must perform FinishLoadingImportedModule(_referrer_, <del>_specifier_</del><ins>_moduleRequest_</ins>, _payload_, _result_) with the same _result_ each time.</p>
+            <p>If this operation is called multiple times with the same <del>(_referrer_, _specifier_) pair</del><ins>(_referrer_, _moduleRequest_.[[Specifier]], _moduleRequest_.[[Attributes]]) triple</ins> and it performs FinishLoadingImportedModule(_referrer_, <del>_specifier_</del><ins>_moduleRequest_</ins>, _payload_, _result_) where _result_ is a normal completion, then it must perform FinishLoadingImportedModule(_referrer_, <del>_specifier_</del><ins>_moduleRequest_</ins>, _payload_, _result_) with the same _result_ each time.</p>
 
             <p><ins>It is recommended but not required that implementations additionally conform to the following stronger constraint:</ins></p>
             <ul>
@@ -148,7 +148,7 @@
             </ul>
           </li>
           <li>
-            <ins>_moduleRequest_.[[Assertions]] must not influence the interpretation of the module or the module specifier; instead, it may be used to determine whether the algorithm completes normally or with an abrupt completion.</ins>
+            <ins>_moduleRequest_.[[Attributes]] must not influence the interpretation of the module or the module specifier; instead, it may be used to determine whether the algorithm completes normally or with an abrupt completion.</ins>
           </li>
           <li>
             The operation must treat _payload_ as an opaque value to be passed through to FinishLoadingImportedModule.
@@ -158,8 +158,8 @@
         <p>The actual process performed is host-defined, but typically consists of performing whatever I/O operations are necessary to load the appropriate Module Record. Multiple different (_referrer_, <del>_specifier_</del><ins>_moduleRequest_.[[Specifier]]</ins>) pairs may map to the same Module Record instance. The actual mapping semantic is host-defined but typically a normalization process is applied to <del>_specifier_</del><ins>_moduleRequest_.[[Specifier]]</ins> as part of the mapping process. A typical normalization process would include actions such as expansion of relative and abbreviated path specifiers.</p>
 
         <emu-note type=editor>
-          <p>The above text implies that is recommended but not required that hosts do not use _moduleRequest_.[[Assertions]] as part of the module cache key. In either case, an exception thrown from an import with a given assertion list does not rule out success of another import with the same specifier but a different assertion list.</p>
-          <p>Assertions do not affect the contents of the module. Future follow-up proposals may relax this restriction with "evaluator attributes" that would change the contents of the module. There are three possible ways to handle multiple imports of the same module with "evaluator attributes":</p>
+          <p>The above text implies that is recommended but not required that hosts do not use _moduleRequest_.[[Attributes]] as part of the module cache key. In either case, an exception thrown from an import with a given attribute list does not rule out success of another import with the same specifier but a different attribute list.</p>
+          <p>Attributes do not affect the contents of the module. Future follow-up proposals may relax this restriction with "evaluator attributes" that would change the contents of the module. There are three possible ways to handle multiple imports of the same module with "evaluator attributes":</p>
           <ul>
             <li><strong>Race</strong> and use the attribute that was requested by the first import. This seems broken--the second usage is ignored.</li>
             <li><strong>Reject</strong> the module graph and don't load if attributes differ. This seems bad for composition--using two unrelated packages together could break, if they load the same module with disagreeing attributes.</li>
@@ -175,9 +175,9 @@
 
         <emu-alg>
           1. If _result_ is a normal completion, then
-            1. If _referrer_.[[LoadedModules]] contains a Record _record_ such that _record_.[[Specifier]] is _moduleRequest_.[[Specifier]] <ins>and AssertionsEqual(_record_.[[Assertions]], _moduleRequest_.[[Assertions]]) is *true*</ins>, then
+            1. If _referrer_.[[LoadedModules]] contains a Record _record_ such that _record_.[[Specifier]] is _moduleRequest_.[[Specifier]] <ins>and AttributesEqual(_record_.[[Attributes]], _moduleRequest_.[[Attributes]]) is *true*</ins>, then
               1. Assert: _record_.[[Module]] is _result_.[[Value]].
-            1. Else, add Record { [[Specifier]]: _moduleRequest_.[[Specifier]], <ins>[[Assertions]]: _moduleRequest_.[[Assertions]]</ins>, [[Module]]: _result_.[[Value]] } to _referrer_.[[LoadedModules]].
+            1. Else, add Record { [[Specifier]]: _moduleRequest_.[[Specifier]], <ins>[[Attributes]]: _moduleRequest_.[[Attributes]]</ins>, [[Module]]: _result_.[[Value]] } to _referrer_.[[LoadedModules]].
           1. If _payload_ is a GraphLoadingState Record, then
             1. Perform ContinueModuleLoading(_payload_, _result_).
           1. Else,
@@ -186,12 +186,12 @@
         </emu-alg>
 
         <emu-note type="editor">
-          <p>The description of the [[LoadedModules]] field of Realm Record, Script Record, and Cyclic Module Record should be updated to include the [[Assertions]] field.</p>
+          <p>The description of the [[LoadedModules]] field of Realm Record, Script Record, and Cyclic Module Record should be updated to include the [[Attributes]] field.</p>
         </emu-note>
 
-        <emu-clause id="sec-FinishLoadingImportedModule-AssertionsEqual" type="abstract operation">
-          <h1><ins>AssertionsEqual(_left_, _right_)</ins></h1>
-          <p>The abstract operation AssertionsEqual takes arguments _left_ and _right_ (two Lists of Records { [[Key]]: a String, [[Value]]: a String }), and returns a Boolean.</p>
+        <emu-clause id="sec-FinishLoadingImportedModule-AttributesEqual" type="abstract operation">
+          <h1><ins>AttributesEqual(_left_, _right_)</ins></h1>
+          <p>The abstract operation AttributesEqual takes arguments _left_ and _right_ (two Lists of Records { [[Key]]: a String, [[Value]]: a String }), and returns a Boolean.</p>
 
           <emu-alg>
             1. If the number of elements in _left_ is not the same as the number of elements in _right_, return *false*.
@@ -206,80 +206,80 @@
         </emu-clause>
       </emu-clause>
 
-  <emu-clause id="sec-hostgetsupportedimportassertions" aoid="HostGetSupportedImportAssertions">
-    <h1>Static Semantics: HostGetSupportedImportAssertions ()</h1>
+  <emu-clause id="sec-HostGetSupportedImportAttributes" aoid="HostGetSupportedImportAttributes">
+    <h1>Static Semantics: HostGetSupportedImportAttributes ()</h1>
     <p>
-      HostGetSupportedImportAssertions is a host-defined abstract operation that allows host environments to specify which import assertions they support.
-      Only assertions with supported keys will be provided to the host.
+      HostGetSupportedImportAttributes is a host-defined abstract operation that allows host environments to specify which import attributes they support.
+      Only attributes with supported keys will be provided to the host.
     </p>
 
-    <p>The implementation of HostGetSupportedImportAssertions must conform to the following requrements:</p>
+    <p>The implementation of HostGetSupportedImportAttributes must conform to the following requrements:</p>
 
     <ul>
-      <li>It must return a List whose values are all StringValues, each indicating a supported assertion.</li>
+      <li>It must return a List whose values are all StringValues, each indicating a supported attribute.</li>
 
       <li>Each time this operation is called, it must return the same List instance with the same contents.</li>
 
-      <li>An implementation of HostGetSupportedImportAssertions must always complete normally (i.e., not return an abrupt completion).</li>
+      <li>An implementation of HostGetSupportedImportAttributes must always complete normally (i.e., not return an abrupt completion).</li>
     </ul>
 
-    <p>The default implementation of HostGetSupportedImportAssertions is to return an empty List.</p>
+    <p>The default implementation of HostGetSupportedImportAttributes is to return an empty List.</p>
 
-    <emu-note type=editor>The purpose of requiring the host to specify its supported import assertions, rather than passing all assertions to the host and letting it then choose which ones it wants to handle, is to ensure that unsupported assertions are handled in a consistent way across different hosts.</emu-note>
+    <emu-note type=editor>The purpose of requiring the host to specify its supported import attributes, rather than passing all attributes to the host and letting it then choose which ones it wants to handle, is to ensure that unsupported attributes are handled in a consistent way across different hosts.</emu-note>
   </emu-clause>
 
-  <emu-clause id="sec-assert-clause-early-errors">
+  <emu-clause id="sec-attribute-clause-early-errors">
     <h1>Static Semantics: Early Errors</h1>
-    <emu-grammar>AssertClause : `assert` `{` AssertEntries `,`? `}`</emu-grammar>
+    <emu-grammar>AttributesClause : `assert` `{` AttributeEntries `,`? `}`</emu-grammar>
     <ul>
-      <li>It is a Syntax Error if AssertClauseToAssertions of |AssertClause| has two entries _a_ and _b_ such that _a_.[[Key]] is _b_.[[Key]].</li>
+      <li>It is a Syntax Error if AttributesClauseToAttributes of |AttributesClause| has two entries _a_ and _b_ such that _a_.[[Key]] is _b_.[[Key]].</li>
     </ul>
   </emu-clause>
 
-  <emu-clause id="sec-assert-clause-to-assertions" aoid="AssertClauseToAssertions">
-    <h1>Static Semantics: AssertClauseToAssertions</h1>
-    <emu-grammar>AssertClause : `assert` `{` `}`</emu-grammar>
+  <emu-clause id="sec-attribute-clause-to-attributes" aoid="AttributesClauseToAttributes">
+    <h1>Static Semantics: AttributesClauseToAttributes</h1>
+    <emu-grammar>AttributesClause : `assert` `{` `}`</emu-grammar>
     <emu-alg>
       1. Return a new empty List.
     </emu-alg>
 
-    <emu-grammar>AssertClause : `assert` `{` AssertEntries `,`? `}`</emu-grammar>
+    <emu-grammar>AttributesClause : `assert` `{` AttributeEntries `,`? `}`</emu-grammar>
     <emu-alg>
-      1. Let _assertions_ be AssertClauseToAssertions of |AssertEntries|.
-      1. Sort _assertions_ by the code point order of the [[Key]] of each element. NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among assertions by the order they occur in.
-      1. Return _assertions_.
+      1. Let _attributes_ be AttributesClauseToAttributes of |AttributeEntries|.
+      1. Sort _attributes_ by the code point order of the [[Key]] of each element. NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among attributes by the order they occur in.
+      1. Return _attributes_.
     </emu-alg>
 
-    <emu-grammar> AssertEntries : AssertionKey `:` StringLiteral </emu-grammar>
+    <emu-grammar> AttributeEntries : AttributeKey `:` StringLiteral </emu-grammar>
     <emu-alg>
-      1. Let _supportedAssertions_ be !HostGetSupportedImportAssertions().
-      1. Let _key_ be StringValue of |AssertionKey|.
-      1. If _supportedAssertions_ contains _key_,
+      1. Let _supportedAttributes_ be !HostGetSupportedImportAttributes().
+      1. Let _key_ be StringValue of |AttributeKey|.
+      1. If _supportedAttributes_ contains _key_,
         1. Let _entry_ be a Record { [[Key]]: _key_, [[Value]]: StringValue of |StringLiteral| }.
         1. Return a new List containing the single element, _entry_.
       1. Otherwise, return a new empty List.
     </emu-alg>
 
-    <emu-grammar> AssertEntries : AssertionKey `:` StringLiteral `,` AssertEntries </emu-grammar>
+    <emu-grammar> AttributeEntries : AttributeKey `:` StringLiteral `,` AttributeEntries </emu-grammar>
     <emu-alg>
-      1. Let _supportedAssertions_ be !HostGetSupportedImportAssertions().
-      1. Let _key_ be StringValue of |AssertionKey|.
-      1. If _supportedAssertions_ contains _key_,
+      1. Let _supportedAttributes_ be !HostGetSupportedImportAttributes().
+      1. Let _key_ be StringValue of |AttributeKey|.
+      1. If _supportedAttributes_ contains _key_,
         1. Let _entry_ be a Record { [[Key]]: _key_, [[Value]]: StringValue of |StringLiteral| }.
-        1. Let _rest_ be AssertClauseToAssertions of |AssertEntries|.
+        1. Let _rest_ be AttributesClauseToAttributes of |AttributeEntries|.
         1. Return a new List containing _entry_ followed by the elements of _rest_.
-      1. Otherwise, return AssertClauseToAssertions of |AssertEntries|.
+      1. Otherwise, return AttributesClauseToAttributes of |AttributeEntries|.
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-assertion-key-string-value">
+  <emu-clause id="sec-attribute-key-string-value">
     <h1>Static Semantics: StringValue</h1>
-    <emu-grammar> AssertionKey : IdentifierName </emu-grammar>
+    <emu-grammar> AttributeKey : IdentifierName </emu-grammar>
     <emu-alg>
       1. Return the StringValue of |IdentifierName|.
     </emu-alg>
 
-    <emu-grammar> AssertionKey : StringLiteral </emu-grammar>
+    <emu-grammar> AttributeKey : StringLiteral </emu-grammar>
     <emu-alg>
       1. Return the StringValue of |StringLiteral|.
     </emu-alg>
@@ -288,7 +288,7 @@
       <emu-clause id="sec-modulerequest-record">
         <h1>ModuleRequest Records</h1>
 
-        <p>A <dfn>ModuleRequest Record</dfn> represents the request to import a module with given import assertions. It consists of the following fields:</p>
+        <p>A <dfn>ModuleRequest Record</dfn> represents the request to import a module with given import attributes. It consists of the following fields:</p>
         <emu-table id="table-modulerequest-fields" caption="ModuleRequest Record fields">
           <table>
             <tbody>
@@ -316,13 +316,13 @@
               </tr>
               <tr>
                 <td>
-                  [[Assertions]]
+                  [[Attributes]]
                 </td>
                 <td>
                   a List of Records { [[Key]]: a String, [[Value]]: a String }
                 </td>
                 <td>
-                  The import assertions
+                  The import attributes
                 </td>
               </tr>
             </tbody>
@@ -399,7 +399,7 @@
                   List of <del>String</del><ins>ModuleRequest Record</ins>
                 </td>
                 <td>
-                  A List of all the |ModuleSpecifier| strings <ins>and import assertions</ins> used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
+                  A List of all the |ModuleSpecifier| strings <ins>and import attributes</ins> used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
                 </td>
               </tr>
             </tbody>
@@ -431,7 +431,7 @@
               </td>
               <td>
                 <del>String value of the |ModuleSpecifier| of the |ImportDeclaration|.</del>
-                <ins>ModuleRequest Record representing the |ModuleSpecifier| and import assertions of the |ImportDeclaration|.</ins>
+                <ins>ModuleRequest Record representing the |ModuleSpecifier| and import attributes of the |ImportDeclaration|.</ins>
               </td>
             </tr>
             <tr>
@@ -467,13 +467,13 @@
         <emu-alg>
           1. <del>Return ModuleRequests of |FromClause|.</del>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Assertions]]: an empty List }.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: an empty List }.</ins>
         </emu-alg>
-        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause AssertClause `;`</emu-grammar>
+        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause AttributesClause `;`</emu-grammar>
         <emu-alg>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Let _assertions_ be AssertClauseToAssertions of |AssertClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Assertions]]: _assertions_ }.</ins>
+          1. <ins>Let _attributes_ be AttributesClauseToAttributes of |AttributesClause|.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: _attributes_ }.</ins>
         </emu-alg>
         <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
@@ -490,7 +490,7 @@
           1. Append to _moduleNames_ each element of _additionalNames_ <del>that is not already an element of _moduleNames_</del>.
           1. Return _moduleNames_.
         </emu-alg>
-        <emu-note type=editor>Deletion of duplicates is an unnecessary "spec optimization" that would be more complicated to explain in terms of examining import assertion records, and can be simply removed.</emu-note>
+        <emu-note type=editor>Deletion of duplicates is an unnecessary "spec optimization" that would be more complicated to explain in terms of examining import attribute records, and can be simply removed.</emu-note>
         <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
@@ -501,15 +501,15 @@
         <emu-alg>
           1. <del>Return ModuleRequests of |FromClause|.</del>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Assertions]]: an empty List }.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: an empty List }.</ins>
         </emu-alg>
         <emu-grammar>
-          ExportDeclaration : `export` ExportFromClause FromClause AssertClause `;`
+          ExportDeclaration : `export` ExportFromClause FromClause AttributesClause `;`
         </emu-grammar>
         <emu-alg>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Let _assertions_ be AssertClauseToAssertions of |AssertClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Assertions]]: _assertions_ }.</ins>
+          1. <ins>Let _attributes_ be AttributesClauseToAttributes of |AttributesClause|.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: _attributes_ }.</ins>
         </emu-alg>
         <emu-grammar>
           ExportDeclaration :
@@ -529,13 +529,13 @@
 <emu-annex id="sec-host-integration">
   <h1>Sample host integration: The Web embedding</h1>
 
-  <p>The import assertions proposal is intended to give key information about how modules are interpreted to hosts. For the Web embedding and environments which aim to be similar to it, the string is interpreted as the "module type". This is not the primary way the module type is determined (which, on the Web, would be the MIME type, and in other environments may be the file extension), but rather a secondary check which is required to pass for the module graph to load.</p>
+  <p>The import attributes proposal is intended to give key information about how modules are interpreted to hosts. For the Web embedding and environments which aim to be similar to it, the string is interpreted as the "module type". This is not the primary way the module type is determined (which, on the Web, would be the MIME type, and in other environments may be the file extension), but rather a secondary check which is required to pass for the module graph to load.</p>
 
-  <p>In the Web embedding, the following changes would be made to the HTML specification for import assertions:</p>
+  <p>In the Web embedding, the following changes would be made to the HTML specification for import attributes:</p>
 
   <ul>
     <li>The <a href="https://html.spec.whatwg.org/#module-script">module script</a> would have an additional item, which would be the module type, as a string (e.g., *"json"*), or *undefined* for a JavaScript module.</li>
-    <li>HostLoadImportedModule would take a ModuleRequest Record parameter in place of a specifier string, which would be passed down through several abstract operations to reach the <a href="https://html.spec.whatwg.org/#fetch-a-single-module-script">fetch a single module script</a> algorithm. Somewhere near the entrypoint, if the ModuleRequest Record's [[Assertions]] field has an element _entry_ such that _entry_.[[Key]] is *"type"*, then let _type_ be _entry_.[[Value]]; otherwise let _type_ be *undefined*. If the type is invalid, then an exception is thrown and module loading fails. Otherwise, this will equal the module type, if the module can be successfully fetched with a matching MIME type.</li>
+    <li>HostLoadImportedModule would take a ModuleRequest Record parameter in place of a specifier string, which would be passed down through several abstract operations to reach the <a href="https://html.spec.whatwg.org/#fetch-a-single-module-script">fetch a single module script</a> algorithm. Somewhere near the entrypoint, if the ModuleRequest Record's [[Attributes]] field has an element _entry_ such that _entry_.[[Key]] is *"type"*, then let _type_ be _entry_.[[Value]]; otherwise let _type_ be *undefined*. If the type is invalid, then an exception is thrown and module loading fails. Otherwise, this will equal the module type, if the module can be successfully fetched with a matching MIME type.</li>
     <li>In the <a href="https://html.spec.whatwg.org/#fetch-the-descendants-of-a-module-script">fetch the descendents of a module script</a> algorithm, when iterating over [[RequestedModules]], the elements are ModuleRequest Records rather than just specifier strings; these Records is passed on to the internal module script graph fetching procedure (which sends it to "fetch a single module script". Other usage sites of [[RequestedModules]] ignore the assertion.</li>
     <li>"Fetch a single module script" would check the assertion in two places:
       <ul>
@@ -545,5 +545,5 @@
     </li>
   </ul>
 
-  <p>The module map is keyed by the absolute URL and the _type_. Initially no other import assertions are supported, so they are not present.</p>
+  <p>The module map is keyed by the absolute URL and the _type_. Initially no other import attributes are supported, so they are not present.</p>
 </emu-annex>

--- a/spec.html
+++ b/spec.html
@@ -2,7 +2,7 @@
 <meta charset="utf8">
 <script src="ecmarkup.js"></script>
 <link rel="stylesheet" href="ecmarkup.css">
-<title>import attributes</title>
+<title>Import Attributes</title>
 <pre class=metadata>
   title: Import attributes
   status: proposal
@@ -12,8 +12,16 @@
   contributors: Sven Sauleau, Myles Borins, Daniel Ehrenberg, Daniel Clark
 </pre>
 <emu-intro id="intro">
-  <h1>import attributes</h1>
-  <p>See <a href="https://github.com/tc39/proposal-import-assertions/blob/master/README.md">the explainer</a> for information.</p>
+  <h1>Import Attributes</h1>
+  <p>Import Attributes are an extension to the import syntax that allows specifying additional information to affect how the module is imported. This proposal, other than defining such syntax, also defines the first import attribtue: `type`, which is passed to the host to specify the expected type of the loaded module. See <a href="https://github.com/tc39/proposal-import-assertions/blob/master/README.md">the explainer</a> for more information.</p>
+  <p>
+    Possible future extensions include:
+    <ul>
+      <li>a `module` attribute, to import an object representing the dependency's Module Record instead of evaluating it;</li>
+      <li>a `defer` attribute, to import a module without evaluating it immediately.</li>
+    </ul>
+  </p>
+  <p>Not every import attribute needs to interact with host semantics, for example `module` and `defer` could be defined completely within ECMA-262.</p>
 </emu-intro>
 
 <emu-clause id="sec-syntax">
@@ -41,8 +49,11 @@
       <ins>`with` `{` AttributeEntries `,`? `}`</ins>
 
     AttributeEntries :
+      <ins>AttributeEntry</ins>
+      <ins>AttributeEntries `,` AttributeEntry</ins>
+
+    AttributeEntry :
       <ins>AttributeKey `:` StringLiteral</ins>
-      <ins>AttributeKey `:` StringLiteral `,` AttributeEntries</ins>
 
     AttributeKey:
       <ins>IdentifierName</ins>
@@ -79,7 +90,7 @@
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. Let _specifierString_ be ToString(_specifier_).
             1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
-            1. Let _attributes_ be a new empty List.
+            1. Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Type]]: ~empty~ }.
             1. If _options_ is not *undefined*, then
               1. If Type(_options_) is not Object,
                 1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
@@ -92,17 +103,16 @@
                   1. Return _promiseCapability_.[[Promise]].
                 1. Let _keys_ be EnumerableOwnPropertyNames(_attributesObj_, ~key~).
                 1. IfAbruptRejectPromise(_keys_, _promiseCapability_).
-                1. Let _supportedAttributes_ be ! HostGetSupportedImportAttributes().
                 1. For each String _key_ of _keys_,
                   1. Let _value_ be Get(_attributesObj_, _key_).
                   1. IfAbruptRejectPromise(_value_, _promiseCapability_).
                   1. If Type(_value_) is not String, then
                     1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
                     1. Return _promiseCapability_.[[Promise]].
-                  1. If _supportedAttributes_ contains _key_, then
-                    1. Append { [[Key]]: _key_, [[Value]]: _value_ } to _attributes_.
-              1. Sort _attributes_ by the code point order of the [[Key]] of each element. NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among attributes by the order they occur in.
-            1. Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Attributes]]: _attributes_ }.
+                  1. If _key_ is *"type"*, then
+                    1. Assert: _moduleRequest_.[[Type]] is ~empty~.
+                    1. Set _moduleRequest_.[[Type]] to _value_.
+                  1. TODO: Throw on unknown keys?
             1. Perform HostLoadImportedModule(_referrer_, _moduleRequest_, ~empty~, _promiseCapability_).
             1. Return _promiseCapability_.[[Promise]].
           </emu-alg>
@@ -138,35 +148,12 @@
             The host environment must perform FinishLoadingImportedModule(_referrer_, <del>_specifier_</del><ins>_moduleRequest_</ins>, _payload_, _result_), where _result_ is either a normal completion containing the loaded Module Record or a throw completion, either synchronously or asynchronously.
           </li>
           <li>
-            <p>If this operation is called multiple times with the same <del>(_referrer_, _specifier_) pair</del><ins>(_referrer_, _moduleRequest_.[[Specifier]], _moduleRequest_.[[Attributes]]) triple</ins> and it performs FinishLoadingImportedModule(_referrer_, <del>_specifier_</del><ins>_moduleRequest_</ins>, _payload_, _result_) where _result_ is a normal completion, then it must perform FinishLoadingImportedModule(_referrer_, <del>_specifier_</del><ins>_moduleRequest_</ins>, _payload_, _result_) with the same _result_ each time.</p>
-
-            <p><ins>It is recommended but not required that implementations additionally conform to the following stronger constraint:</ins></p>
-            <ul>
-              <li>
-                <ins>If this operation is called multiple times with the same (_referrer_, _moduleRequest_.[[Specifier]]) pair and it performs FinishLoadingImportedModule(_referrer_, _moduleRequest_, _payload_, _result_) where _result_ is a normal completion, then it must perform FinishLoadingImportedModule(_referrer_, _moduleRequest_, _payload_, _result_) with the same _result_ each time.</ins>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <ins>_moduleRequest_.[[Attributes]] must not influence the interpretation of the module or the module specifier; instead, it may be used to determine whether the algorithm completes normally or with an abrupt completion.</ins>
+            <p>If this operation is called multiple times with the same <del>(_referrer_, _specifier_) pair</del><ins>(_referrer_, _moduleRequest_.[[Specifier]], _moduleRequest_.[[Type]]) triple</ins> and it performs FinishLoadingImportedModule(_referrer_, <del>_specifier_</del><ins>_moduleRequest_</ins>, _payload_, _result_) where _result_ is a normal completion, then it must perform FinishLoadingImportedModule(_referrer_, <del>_specifier_</del><ins>_moduleRequest_</ins>, _payload_, _result_) with the same _result_ each time.</p>
           </li>
           <li>
             The operation must treat _payload_ as an opaque value to be passed through to FinishLoadingImportedModule.
           </li>
         </ul>
-
-        <p>The actual process performed is host-defined, but typically consists of performing whatever I/O operations are necessary to load the appropriate Module Record. Multiple different (_referrer_, <del>_specifier_</del><ins>_moduleRequest_.[[Specifier]]</ins>) pairs may map to the same Module Record instance. The actual mapping semantic is host-defined but typically a normalization process is applied to <del>_specifier_</del><ins>_moduleRequest_.[[Specifier]]</ins> as part of the mapping process. A typical normalization process would include actions such as expansion of relative and abbreviated path specifiers.</p>
-
-        <emu-note type=editor>
-          <p>The above text implies that is recommended but not required that hosts do not use _moduleRequest_.[[Attributes]] as part of the module cache key. In either case, an exception thrown from an import with a given attribute list does not rule out success of another import with the same specifier but a different attribute list.</p>
-          <p>Attributes do not affect the contents of the module. Future follow-up proposals may relax this restriction with "evaluator attributes" that would change the contents of the module. There are three possible ways to handle multiple imports of the same module with "evaluator attributes":</p>
-          <ul>
-            <li><strong>Race</strong> and use the attribute that was requested by the first import. This seems broken--the second usage is ignored.</li>
-            <li><strong>Reject</strong> the module graph and don't load if attributes differ. This seems bad for composition--using two unrelated packages together could break, if they load the same module with disagreeing attributes.</li>
-            <li><strong>Clone</strong> and make two copies of the module, for the different ways it's transformed. In this case, the attributes would have to be part of the cache key. These semantics would run counter to the intuition that there is just one copy of a module.</li>
-          </ul>
-          <p>It's possible that one of these three options may make sense for a module load, on a case-by-case basis by attribute, but it's worth careful thought before making this choice.</p>
-        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-FinishLoadingImportedModule" type="abstract operation">
@@ -175,9 +162,9 @@
 
         <emu-alg>
           1. If _result_ is a normal completion, then
-            1. If _referrer_.[[LoadedModules]] contains a Record _record_ such that _record_.[[Specifier]] is _moduleRequest_.[[Specifier]] <ins>and AttributesEqual(_record_.[[Attributes]], _moduleRequest_.[[Attributes]]) is *true*</ins>, then
+            1. If _referrer_.[[LoadedModules]] contains a Record _record_ such that _record_.[[Specifier]] is _moduleRequest_.[[Specifier]] <ins>and _record_.[[Type]] is _moduleRequest_.[[Type]]</ins>, then
               1. Assert: _record_.[[Module]] is _result_.[[Value]].
-            1. Else, add Record { [[Specifier]]: _moduleRequest_.[[Specifier]], <ins>[[Attributes]]: _moduleRequest_.[[Attributes]]</ins>, [[Module]]: _result_.[[Value]] } to _referrer_.[[LoadedModules]].
+            1. Else, add Record { [[Specifier]]: _moduleRequest_.[[Specifier]], <ins>[[Type]]: _moduleRequest_.[[Type]]</ins>, [[Module]]: _result_.[[Value]] } to _referrer_.[[LoadedModules]].
           1. If _payload_ is a GraphLoadingState Record, then
             1. Perform ContinueModuleLoading(_payload_, _result_).
           1. Else,
@@ -186,102 +173,25 @@
         </emu-alg>
 
         <emu-note type="editor">
-          <p>The description of the [[LoadedModules]] field of Realm Record, Script Record, and Cyclic Module Record should be updated to include the [[Attributes]] field.</p>
+          <p>The description of the [[LoadedModules]] field of Realm Record, Script Record, and Cyclic Module Record should be updated to include the [[Type]] field.</p>
         </emu-note>
-
-        <emu-clause id="sec-FinishLoadingImportedModule-AttributesEqual" type="abstract operation">
-          <h1><ins>AttributesEqual(_left_, _right_)</ins></h1>
-          <p>The abstract operation AttributesEqual takes arguments _left_ and _right_ (two Lists of Records { [[Key]]: a String, [[Value]]: a String }), and returns a Boolean.</p>
-
-          <emu-alg>
-            1. If the number of elements in _left_ is not the same as the number of elements in _right_, return *false*.
-            1. For each Record { [[Key]], [[Value]] } _r_ of _left_, do
-              1. Let _found_ be *false*.
-              1. For each Record { [[Key]], [[Value]] } _s_ of _right_, do
-                1. If _r_.[[Key]] is _s_.[[Key]] and _r_.[[Value]] is _s_.[[Value]], then
-                  1. Set _found_ to *true*.
-              1. If _found_ is *false*, return *false*.
-            1. Return *true*.
-          </emu-alg>
-        </emu-clause>
       </emu-clause>
 
-  <emu-clause id="sec-HostGetSupportedImportAttributes" aoid="HostGetSupportedImportAttributes">
-    <h1>Static Semantics: HostGetSupportedImportAttributes ()</h1>
-    <p>
-      HostGetSupportedImportAttributes is a host-defined abstract operation that allows host environments to specify which import attributes they support.
-      Only attributes with supported keys will be provided to the host.
-    </p>
-
-    <p>The implementation of HostGetSupportedImportAttributes must conform to the following requrements:</p>
-
-    <ul>
-      <li>It must return a List whose values are all StringValues, each indicating a supported attribute.</li>
-
-      <li>Each time this operation is called, it must return the same List instance with the same contents.</li>
-
-      <li>An implementation of HostGetSupportedImportAttributes must always complete normally (i.e., not return an abrupt completion).</li>
-    </ul>
-
-    <p>The default implementation of HostGetSupportedImportAttributes is to return an empty List.</p>
-
-    <emu-note type=editor>The purpose of requiring the host to specify its supported import attributes, rather than passing all attributes to the host and letting it then choose which ones it wants to handle, is to ensure that unsupported attributes are handled in a consistent way across different hosts.</emu-note>
-  </emu-clause>
-
-  <emu-clause id="sec-attribute-clause-early-errors">
-    <h1>Static Semantics: Early Errors</h1>
-    <emu-grammar>AttributesClause : `with` `{` AttributeEntries `,`? `}`</emu-grammar>
-    <ul>
-      <li>It is a Syntax Error if AttributesClauseToAttributes of |AttributesClause| has two entries _a_ and _b_ such that _a_.[[Key]] is _b_.[[Key]].</li>
-    </ul>
-  </emu-clause>
-
-  <emu-clause id="sec-attribute-clause-to-attributes" aoid="AttributesClauseToAttributes">
-    <h1>Static Semantics: AttributesClauseToAttributes</h1>
-    <emu-grammar>AttributesClause : `with` `{` `}`</emu-grammar>
+  <emu-clause id="sec-collect-import-attributes" aoid="CollectImportAttributes">
+    <h1>Static Semantics: CollectImportAttributes ( _moduleRequest_ )</h1>
+    <emu-grammar> AttributeEntries : AttributeEntries `,` AttributeEntry </emu-grammar>
     <emu-alg>
-      1. Return a new empty List.
+      1. Perform CollectImportAttributes of |AttributeEntries| with parameters &laquo; _moduleRequest_ &raquo;.
+      1. Perform CollectImportAttributes of |AttributeEntry| with parameters &laquo; _moduleRequest_ &raquo;.
     </emu-alg>
 
-    <emu-grammar>AttributesClause : `with` `{` AttributeEntries `,`? `}`</emu-grammar>
+    <emu-grammar> AttributeEntry : AttributeKey `:` StringLiteral </emu-grammar>
     <emu-alg>
-      1. Let _attributes_ be AttributesClauseToAttributes of |AttributeEntries|.
-      1. Sort _attributes_ by the code point order of the [[Key]] of each element. NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among attributes by the order they occur in.
-      1. Return _attributes_.
-    </emu-alg>
-
-    <emu-grammar> AttributeEntries : AttributeKey `:` StringLiteral </emu-grammar>
-    <emu-alg>
-      1. Let _supportedAttributes_ be !HostGetSupportedImportAttributes().
       1. Let _key_ be StringValue of |AttributeKey|.
-      1. If _supportedAttributes_ contains _key_,
-        1. Let _entry_ be a Record { [[Key]]: _key_, [[Value]]: StringValue of |StringLiteral| }.
-        1. Return a new List containing the single element, _entry_.
-      1. Otherwise, return a new empty List.
-    </emu-alg>
-
-    <emu-grammar> AttributeEntries : AttributeKey `:` StringLiteral `,` AttributeEntries </emu-grammar>
-    <emu-alg>
-      1. Let _supportedAttributes_ be !HostGetSupportedImportAttributes().
-      1. Let _key_ be StringValue of |AttributeKey|.
-      1. If _supportedAttributes_ contains _key_,
-        1. Let _entry_ be a Record { [[Key]]: _key_, [[Value]]: StringValue of |StringLiteral| }.
-        1. Let _rest_ be AttributesClauseToAttributes of |AttributeEntries|.
-        1. Return a new List containing _entry_ followed by the elements of _rest_.
-      1. Otherwise, return AttributesClauseToAttributes of |AttributeEntries|.
-    </emu-alg>
-  </emu-clause>
-
-  <emu-clause id="sec-attribute-key-string-value">
-    <h1>Static Semantics: StringValue</h1>
-    <emu-grammar> AttributeKey : IdentifierName </emu-grammar>
-    <emu-alg>
-      1. Return the StringValue of |IdentifierName|.
-    </emu-alg>
-
-    <emu-grammar> AttributeKey : StringLiteral </emu-grammar>
-    <emu-alg>
-      1. Return the StringValue of |StringLiteral|.
+      1. If _key_ is *"type"*, then
+        1. If _moduleRequest_.[[Type]] is not ~empty~, throw a SyntaxError exception.
+        1. Set _moduleRequest_.[[Type]] to the StringValue of |StringLiteral|.
+      1. TODO: Throw on unknown keys?
     </emu-alg>
   </emu-clause>
 
@@ -316,13 +226,13 @@
               </tr>
               <tr>
                 <td>
-                  [[Attributes]]
+                  [[Type]]
                 </td>
                 <td>
-                  a List of Records { [[Key]]: a String, [[Value]]: a String }
+                  a String, or ~empty~
                 </td>
                 <td>
-                  The import attributes
+                  The `type` attribute of this import
                 </td>
               </tr>
             </tbody>
@@ -399,7 +309,7 @@
                   List of <del>String</del><ins>ModuleRequest Record</ins>
                 </td>
                 <td>
-                  A List of all the |ModuleSpecifier| strings <ins>and import attributes</ins> used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
+                  A List of all the |ModuleSpecifier| strings <ins>with the corresponding `type` import attribute</ins> used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
                 </td>
               </tr>
             </tbody>
@@ -431,7 +341,7 @@
               </td>
               <td>
                 <del>String value of the |ModuleSpecifier| of the |ImportDeclaration|.</del>
-                <ins>ModuleRequest Record representing the |ModuleSpecifier| and import attributes of the |ImportDeclaration|.</ins>
+                <ins>ModuleRequest Record representing the |ModuleSpecifier| and the `type` import attribute of the |ImportDeclaration|.</ins>
               </td>
             </tr>
             <tr>
@@ -466,14 +376,15 @@
         <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
         <emu-alg>
           1. <del>Return ModuleRequests of |FromClause|.</del>
-          1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: an empty List }.</ins>
+          1. <ins>Let _specifier_ be StringValue of |FromClause|.</ins>
+          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Type]]: ~empty~ }.</ins>
         </emu-alg>
         <emu-grammar>ImportDeclaration : `import` ImportClause FromClause AttributesClause `;`</emu-grammar>
         <emu-alg>
-          1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Let _attributes_ be AttributesClauseToAttributes of |AttributesClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: _attributes_ }.</ins>
+          1. <ins>Let _specifier_ be StringValue of |FromClause|.</ins>
+          1. <ins>Let _request_ be the ModuleRequest Record { [[Specifer]]: _specifier_, [[Type]]: ~empty~ }.</ins>
+          1. <ins>Perform CollectImportAttributes of |AttributesClause| with argument _request_.</ins>
+          1. <ins>Return _request_.</ins>
         </emu-alg>
         <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
@@ -487,10 +398,9 @@
         <emu-alg>
           1. Let _moduleNames_ be ModuleRequests of |ModuleItemList|.
           1. Let _additionalNames_ be ModuleRequests of |ModuleItem|.
-          1. Append to _moduleNames_ each element of _additionalNames_ <del>that is not already an element of _moduleNames_</del>.
+          1. Append to _moduleNames_ each element of _additionalNames_ that is not already an element of _moduleNames_.
           1. Return _moduleNames_.
         </emu-alg>
-        <emu-note type=editor>Deletion of duplicates is an unnecessary "spec optimization" that would be more complicated to explain in terms of examining import attribute records, and can be simply removed.</emu-note>
         <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
@@ -500,16 +410,17 @@
         </emu-grammar>
         <emu-alg>
           1. <del>Return ModuleRequests of |FromClause|.</del>
-          1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: an empty List }.</ins>
+          1. <ins>Let _specifier_ be StringValue of |FromClause|.</ins>
+          1. <ins>Return the ModuleRequest Record { [[Specifer]]: _specifier_, [[Type]]: ~empty~ }.</ins>
         </emu-alg>
         <emu-grammar>
           ExportDeclaration : `export` ExportFromClause FromClause AttributesClause `;`
         </emu-grammar>
         <emu-alg>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Let _attributes_ be AttributesClauseToAttributes of |AttributesClause|.</ins>
-          1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Attributes]]: _attributes_ }.</ins>
+          1. <ins>Let _request_ be the ModuleRequest Record { [[Specifer]]: _specifier_, [[Type]]: ~empty~ }.</ins>
+          1. <ins>Perform CollectImportAttributes of |AttributesClause| with argument _request_.</ins>
+          1. <ins>Return _request_.</ins>
         </emu-alg>
         <emu-grammar>
           ExportDeclaration :
@@ -535,7 +446,7 @@
 
   <ul>
     <li>The <a href="https://html.spec.whatwg.org/#module-script">module script</a> would have an additional item, which would be the module type, as a string (e.g., *"json"*), or *undefined* for a JavaScript module.</li>
-    <li>HostLoadImportedModule would take a ModuleRequest Record parameter in place of a specifier string, which would be passed down through several abstract operations to reach the <a href="https://html.spec.whatwg.org/#fetch-a-single-module-script">fetch a single module script</a> algorithm. Somewhere near the entrypoint, if the ModuleRequest Record's [[Attributes]] field has an element _entry_ such that _entry_.[[Key]] is *"type"*, then let _type_ be _entry_.[[Value]]; otherwise let _type_ be *undefined*. If the type is invalid, then an exception is thrown and module loading fails. Otherwise, this will equal the module type, if the module can be successfully fetched with a matching MIME type.</li>
+    <li>HostLoadImportedModule would take a ModuleRequest Record parameter in place of a specifier string, which would be passed down through several abstract operations to reach the <a href="https://html.spec.whatwg.org/#fetch-a-single-module-script">fetch a single module script</a> algorithm. Somewhere near the entrypoint, if the ModuleRequest Record's [[Type]] field has an element _entry_ such that _entry_.[[Key]] is *"type"*, then let _type_ be _entry_.[[Value]]; otherwise let _type_ be *undefined*. If the type is invalid, then an exception is thrown and module loading fails. Otherwise, this will equal the module type, if the module can be successfully fetched with a matching MIME type.</li>
     <li>In the <a href="https://html.spec.whatwg.org/#fetch-the-descendants-of-a-module-script">fetch the descendents of a module script</a> algorithm, when iterating over [[RequestedModules]], the elements are ModuleRequest Records rather than just specifier strings; these Records is passed on to the internal module script graph fetching procedure (which sends it to "fetch a single module script". Other usage sites of [[RequestedModules]] ignore the assertion.</li>
     <li>"Fetch a single module script" would check the assertion in two places:
       <ul>

--- a/spec.html
+++ b/spec.html
@@ -37,8 +37,8 @@
       `export` `default` [lookahead &lt;! {`function`, `async` [no |LineTerminator| here] `function`, `class`}] AssignmentExpression[+In, ~Yield, ~Await] `;`
 
     AttributesClause :
-      <ins>`assert` `{` `}`</ins>
-      <ins>`assert` `{` AttributeEntries `,`? `}`</ins>
+      <ins>`with` `{` `}`</ins>
+      <ins>`with` `{` AttributeEntries `,`? `}`</ins>
 
     AttributeEntries :
       <ins>AttributeKey `:` StringLiteral</ins>
@@ -84,7 +84,7 @@
               1. If Type(_options_) is not Object,
                 1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
                 1. Return _promiseCapability_.[[Promise]].
-              1. Let _attributesObj_ be Get(_options_, *"assert"*).
+              1. Let _attributesObj_ be Get(_options_, *"with"*).
               1. IfAbruptRejectPromise(_attributesObj_, _promiseCapability_).
               1. If _attributesObj_ is not *undefined*,
                 1. If Type(_attributesObj_) is not Object,
@@ -230,7 +230,7 @@
 
   <emu-clause id="sec-attribute-clause-early-errors">
     <h1>Static Semantics: Early Errors</h1>
-    <emu-grammar>AttributesClause : `assert` `{` AttributeEntries `,`? `}`</emu-grammar>
+    <emu-grammar>AttributesClause : `with` `{` AttributeEntries `,`? `}`</emu-grammar>
     <ul>
       <li>It is a Syntax Error if AttributesClauseToAttributes of |AttributesClause| has two entries _a_ and _b_ such that _a_.[[Key]] is _b_.[[Key]].</li>
     </ul>
@@ -238,12 +238,12 @@
 
   <emu-clause id="sec-attribute-clause-to-attributes" aoid="AttributesClauseToAttributes">
     <h1>Static Semantics: AttributesClauseToAttributes</h1>
-    <emu-grammar>AttributesClause : `assert` `{` `}`</emu-grammar>
+    <emu-grammar>AttributesClause : `with` `{` `}`</emu-grammar>
     <emu-alg>
       1. Return a new empty List.
     </emu-alg>
 
-    <emu-grammar>AttributesClause : `assert` `{` AttributeEntries `,`? `}`</emu-grammar>
+    <emu-grammar>AttributesClause : `with` `{` AttributeEntries `,`? `}`</emu-grammar>
     <emu-alg>
       1. Let _attributes_ be AttributesClauseToAttributes of |AttributeEntries|.
       1. Sort _attributes_ by the code point order of the [[Key]] of each element. NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among attributes by the order they occur in.


### PR DESCRIPTION
This PR:
- changes the proposal to only pass `type` to the engine, reserving everything else for future use
- more explicitly allows `type` to be part of the cache key
- changes the keyword from `assert` to `with`, since it's not just asserting anymore

**This is a draft. Please don't focus on the exact syntax, but on the general idea.**

Ref https://github.com/whatwg/html/issues/7233, https://gist.github.com/peetklecha/a55532165dbd4905aa91bbe59e8b1001

Preview: https://raw.githack.com/nicolo-ribaudo/proposal-import-assertions/attributes/dist/index.html